### PR TITLE
feat: Adds explicit Add button for new notes

### DIFF
--- a/components/note-dialog.tsx
+++ b/components/note-dialog.tsx
@@ -42,6 +42,7 @@ export function NoteDialog({
   const initialNoteRef = useRef<string>("");
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const isInitialMount = useRef(true);
+  const isNewNote = !note;
 
   useEffect(() => {
     if (open) {
@@ -58,9 +59,9 @@ export function NoteDialog({
     }
   }, [open, note]);
 
-  // Handle dialog close with immediate save if needed
+  // Handle dialog close with immediate save if needed (only for existing notes)
   const handleDialogClose = (open: boolean) => {
-    if (!open && noteText !== initialNoteRef.current) {
+    if (!open && !isNewNote && noteText !== initialNoteRef.current) {
       // Cancel pending timeout
       if (saveTimeoutRef.current) {
         clearTimeout(saveTimeoutRef.current);
@@ -74,9 +75,9 @@ export function NoteDialog({
     onOpenChange(open);
   };
 
-  // Auto-save with debouncing
+  // Auto-save with debouncing (only for existing notes)
   useEffect(() => {
-    if (!open) return;
+    if (!open || isNewNote) return;
 
     // Skip initial mount
     if (isInitialMount.current) {
@@ -104,11 +105,18 @@ export function NoteDialog({
         clearTimeout(saveTimeoutRef.current);
       }
     };
-  }, [noteText, open, onSubmit, onDelete, note]);
+  }, [noteText, open, onSubmit, isNewNote]);
 
   const handleDelete = () => {
     if (onDelete) {
       onDelete();
+      onOpenChange(false);
+    }
+  };
+
+  const handleAdd = () => {
+    if (noteText.trim()) {
+      onSubmit(noteText);
       onOpenChange(false);
     }
   };
@@ -173,6 +181,16 @@ export function NoteDialog({
               >
                 {t("common.close")}
               </Button>
+              {isNewNote && (
+                <Button
+                  type="button"
+                  onClick={handleAdd}
+                  disabled={!noteText.trim()}
+                  className="h-11 shadow-lg hover:shadow-xl transition-all"
+                >
+                  {t("common.add")}
+                </Button>
+              )}
             </div>
           </div>
         </div>


### PR DESCRIPTION
Prevents automatic saving of newly created notes and gives users an explicit Add action to commit them. Keeps debounced auto-save and immediate save-on-close behavior for existing notes only, avoiding premature or unintended saves during creation.

Adds a dedicated Add button (disabled when the note is empty) that submits the new note and closes the dialog, and adjusts save/close logic and effects accordingly to distinguish new vs existing notes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New notes now display an "Add" button for explicit submission in the dialog.

* **Improvements**
  * Enhanced dialog behavior to distinguish between new and existing notes with separate controls (new notes use Add button; existing notes use Delete and Close buttons).
  * Optimized auto-save behavior based on note state.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->