### PR TITLE
feat: Add shift duration tracking to stats and enhance UI

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -163,7 +163,7 @@ The translation files use a centralized structure to eliminate duplicates and en
 
 ```typescript
 // Success/Error Messages - use {item} parameter
-toast.success(t("common.created", { item: t("shift.title") }));
+toast.success(t("common.created", { item: t("common.shifts") }));
 toast.error(t("common.createError", { item: t("calendar.title") }));
 toast.success(t("common.updated", { item: t("preset.create") }));
 toast.error(t("common.deleteError", { item: t("note.note") }));

--- a/components/day-shifts-dialog.tsx
+++ b/components/day-shifts-dialog.tsx
@@ -49,7 +49,7 @@ export function DayShiftsDialog({
           </DialogTitle>
           <DialogDescription className="text-sm text-muted-foreground">
             {shifts.length}{" "}
-            {shifts.length === 1 ? t("shift.shift_one") : t("shift.shifts")}
+            {shifts.length === 1 ? t("shift.shift_one") : t("common.shifts")}
           </DialogDescription>
         </DialogHeader>
 

--- a/components/shift-stats.tsx
+++ b/components/shift-stats.tsx
@@ -218,7 +218,7 @@ export function ShiftStats({
                     {/* Shift Count */}
                     <div className="flex flex-col items-end">
                       <span className="text-[10px] text-muted-foreground font-medium mb-0.5">
-                        Schichten
+                        {t("common.shifts")}
                       </span>
                       <div className="px-2.5 py-1 rounded-md bg-gradient-to-r from-primary/20 to-primary/10 border border-primary/30">
                         <span className="font-bold text-base sm:text-lg bg-gradient-to-r from-primary to-primary/70 bg-clip-text text-transparent">
@@ -232,7 +232,7 @@ export function ShiftStats({
                         {/* Duration */}
                         <div className="flex flex-col items-end">
                           <span className="text-[10px] text-muted-foreground font-medium mb-0.5">
-                            Stunden
+                            {t("stats.hours")}
                           </span>
                           <div className="px-2.5 py-1 rounded-md bg-gradient-to-r from-primary/20 to-primary/10 border border-primary/30">
                             <span className="font-bold text-base sm:text-lg bg-gradient-to-r from-primary to-primary/70 bg-clip-text text-transparent">

--- a/components/shifts-list.tsx
+++ b/components/shifts-list.tsx
@@ -58,7 +58,7 @@ export function ShiftsList({
             <CalendarIcon className="h-4 w-4 sm:h-5 sm:w-5 text-primary-foreground" />
           </div>
           <h3 className="text-sm sm:text-base font-semibold bg-gradient-to-r from-foreground to-foreground/70 bg-clip-text">
-            {t("shift.title")}
+            {t("common.shifts")}
           </h3>
         </div>
         <div className="flex items-center gap-3">
@@ -147,7 +147,7 @@ export function ShiftsList({
                             {dayShifts.length}{" "}
                             {dayShifts.length === 1
                               ? t("shift.shift_one")
-                              : t("shift.shifts")}
+                              : t("common.shifts")}
                           </div>
                         </div>
                       </div>

--- a/lib/date-utils.ts
+++ b/lib/date-utils.ts
@@ -19,8 +19,30 @@ export function calculateShiftDuration(
   startTime: string,
   endTime: string
 ): number {
+  // Validate time format (HH:MM)
+  const timeRegex = /^([0-1]?[0-9]|2[0-3]):([0-5][0-9])$/;
+  if (!timeRegex.test(startTime) || !timeRegex.test(endTime)) {
+    console.error(
+      `Invalid time format: startTime="${startTime}", endTime="${endTime}"`
+    );
+    return 0; // Return 0 for invalid formats
+  }
+
   const [startHour, startMinute] = startTime.split(":").map(Number);
   const [endHour, endMinute] = endTime.split(":").map(Number);
+
+  // Additional validation for NaN values
+  if (
+    isNaN(startHour) ||
+    isNaN(startMinute) ||
+    isNaN(endHour) ||
+    isNaN(endMinute)
+  ) {
+    console.error(
+      `Invalid time values: startTime="${startTime}", endTime="${endTime}"`
+    );
+    return 0;
+  }
 
   const startMinutes = startHour * 60 + startMinute;
   let endMinutes = endHour * 60 + endMinute;
@@ -35,10 +57,16 @@ export function calculateShiftDuration(
 
 /**
  * Formats duration in minutes to HH:MM format
- * @param minutes - Duration in minutes
+ * @param minutes - Duration in minutes (must be non-negative)
  * @returns Formatted duration string (e.g., "8:30")
  */
 export function formatDuration(minutes: number): string {
+  // Handle negative values or invalid inputs
+  if (minutes < 0 || isNaN(minutes)) {
+    console.error(`Invalid duration: ${minutes} minutes`);
+    return "0:00";
+  }
+
   const hours = Math.floor(minutes / 60);
   const mins = minutes % 60;
   return `${hours}:${String(mins).padStart(2, "0")}`;

--- a/messages/de.json
+++ b/messages/de.json
@@ -23,7 +23,8 @@
     "updateError": "{item} konnte nicht aktualisiert werden",
     "deleteError": "{item} konnte nicht gelöscht werden",
     "deleteConfirm": "{item} \"{name}\" wirklich löschen?",
-    "deleteConfirmWithWarning": "{item} \"{name}\" wirklich löschen? {warning}"
+    "deleteConfirmWithWarning": "{item} \"{name}\" wirklich löschen? {warning}",
+    "shifts": "Schichten"
   },
   "validation": {
     "passwordMatch": "Passwörter stimmen nicht überein",
@@ -97,7 +98,6 @@
     "hintDesktop": "Rechtsklick auf einen Tag öffnet Notizen. Das Notiz-Icon zeigt vorhandene Notizen an."
   },
   "shift": {
-    "title": "Schichten",
     "create": "Neue Schicht",
     "createDescription": "Füge eine neue Schicht zu deinem Kalender hinzu",
     "edit": "Schicht bearbeiten",
@@ -111,7 +111,6 @@
     "allDayShift": "Ganztägige Schicht",
     "noShiftsInMonth": "Keine Schichten in diesem Monat",
     "noShiftsInMonthDescription": "Füge Schichten hinzu, indem du auf Tage im Kalender oben klickst.",
-    "shifts": "Schichten",
     "shift_one": "Schicht",
     "selectPreset": "Vorlage auswählen",
     "none": "Keine",
@@ -179,7 +178,8 @@
     "month": "Monat",
     "year": "Jahr",
     "total": "Gesamt",
-    "noData": "Keine Schichten in diesem Zeitraum"
+    "noData": "Keine Schichten in diesem Zeitraum",
+    "hours": "Stunden"
   },
   "sync": {
     "refreshing": "Aktualisiere Daten...",
@@ -192,9 +192,6 @@
     "welcome": "Willkommen bei BetterShift",
     "description": "Erstelle deinen ersten Kalender, um deine Schichten zu verwalten.",
     "createCalendar": "Kalender erstellen"
-  },
-  "version": {
-    "label": "Version"
   },
   "footer": {
     "version": "Version",

--- a/messages/en.json
+++ b/messages/en.json
@@ -23,7 +23,8 @@
     "updateError": "Failed to update {item}",
     "deleteError": "Failed to delete {item}",
     "deleteConfirm": "Really delete {item} \"{name}\"?",
-    "deleteConfirmWithWarning": "Really delete {item} \"{name}\"? {warning}"
+    "deleteConfirmWithWarning": "Really delete {item} \"{name}\"? {warning}",
+    "shifts": "Shifts"
   },
   "validation": {
     "passwordMatch": "Passwords do not match",
@@ -97,7 +98,6 @@
     "hintDesktop": "Right-click on a day to open notes. The note icon shows existing notes."
   },
   "shift": {
-    "title": "Shifts",
     "create": "New Shift",
     "createDescription": "Add a new shift to your calendar",
     "edit": "Edit Shift",
@@ -111,7 +111,6 @@
     "allDayShift": "All-day shift",
     "noShiftsInMonth": "No shifts this month",
     "noShiftsInMonthDescription": "Add shifts by clicking on days in the calendar above.",
-    "shifts": "shifts",
     "shift_one": "shift",
     "selectPreset": "Select Preset",
     "none": "None",
@@ -179,7 +178,8 @@
     "month": "Month",
     "year": "Year",
     "total": "Total",
-    "noData": "No shifts in this period"
+    "noData": "No shifts in this period",
+    "hours": "Hours"
   },
   "sync": {
     "refreshing": "Refreshing data...",
@@ -192,9 +192,6 @@
     "welcome": "Welcome to BetterShift",
     "description": "Create your first calendar to manage your shifts.",
     "createCalendar": "Create Calendar"
-  },
-  "version": {
-    "label": "Version"
   },
   "footer": {
     "version": "Version",

--- a/messages/it.json
+++ b/messages/it.json
@@ -23,7 +23,8 @@
     "updateError": "Impossibile aggiornare {item}",
     "deleteError": "Impossibile eliminare {item}",
     "deleteConfirm": "Eliminare davvero {item} \"{name}\"?",
-    "deleteConfirmWithWarning": "Eliminare davvero {item} \"{name}\"? {warning}"
+    "deleteConfirmWithWarning": "Eliminare davvero {item} \"{name}\"? {warning}",
+    "shifts": "Turni"
   },
   "validation": {
     "passwordMatch": "Le password non corrispondono",
@@ -97,7 +98,6 @@
     "hintDesktop": "Fai clic con il pulsante destro del mouse su un giorno per aprire le note. L'icona della nota indica le note esistenti."
   },
   "shift": {
-    "title": "Turni",
     "create": "Nuovo Turno",
     "createDescription": "Aggiungi un nuovo turno al tuo calendario",
     "edit": "Modifica Turno",
@@ -111,7 +111,6 @@
     "allDayShift": "Turno di un'intera giornata",
     "noShiftsInMonth": "Nessun turno questo mese",
     "noShiftsInMonthDescription": "Aggiungi turni cliccando sui giorni nel calendario in alto.",
-    "shifts": "turni",
     "shift_one": "turno",
     "selectPreset": "Seleziona Preset",
     "none": "Nessuno",
@@ -178,7 +177,8 @@
     "month": "Mese",
     "year": "Anno",
     "total": "Totale",
-    "noData": "Nessun turno in questo periodo"
+    "noData": "Nessun turno in questo periodo",
+    "hours": "Ore"
   },
   "sync": {
     "refreshing": "Aggiornamento dati...",
@@ -191,9 +191,6 @@
     "welcome": "Benvenuto in BetterShift",
     "description": "Crea il tuo primo calendario per gestire i tuoi turni.",
     "createCalendar": "Crea Calendario"
-  },
-  "version": {
-    "label": "Versione"
   },
   "footer": {
     "version": "Versione",


### PR DESCRIPTION
Adds duration tracking to shift statistics and surfaces total and per-type durations in the UI.

Introduces duration calculation (handles overnight shifts and excludes all-day shifts) and aggregates totalMinutes per shift title and overall. Updates the stats API shape to return count and totalMinutes instead of a raw SQL count, and removes an unused SQL import.

Adds utility functions to format durations and uses them in the UI. Enhances the stats component to show total shifts, formatted total hours, per-shift progress bars, count badges, and duration badges for clearer visibility of time spent.

Improves readability and usability of shift metrics for easier analysis of distribution and time allocation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Shift statistics now include total duration (hours) alongside counts; UI updated with total stats card and per-type duration badges and progress bars.
* **Breaking Changes**
  * Stats API response shape changed: each type includes count and totalMinutes, and a top-level totalMinutes is now returned; error handling added for failures.
* **Localization**
  * Added common "shifts" and "hours" keys; removed some legacy shift/title keys and a version label.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->