### PR TITLE
fix: update banner & loading skeleton in calender grid

### DIFF
--- a/app/api/version/route.ts
+++ b/app/api/version/route.ts
@@ -44,7 +44,10 @@ function getDockerVersion(): string | null {
   try {
     const versionFilePath = join(process.cwd(), ".version");
     if (existsSync(versionFilePath)) {
-      cachedDockerVersion = readFileSync(versionFilePath, "utf-8").trim();
+      // Remove 'v' prefix for consistent version comparison
+      cachedDockerVersion = readFileSync(versionFilePath, "utf-8")
+        .trim()
+        .replace(/^v/, "");
       return cachedDockerVersion;
     }
   } catch {


### PR DESCRIPTION
Strip a leading "v" from the project version file for consistent version comparisons and parsing.

Refactor shift fetching to accept a silent mode so live updates can refresh data without toggling the global loading indicator. Also improve error handling by clearing shifts when the calendar is locked or a fetch fails and logging failures for easier debugging.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed version string formatting to ensure consistent and accurate version comparisons.

* **Improvements**
  * Enhanced loading state management for shift data operations, enabling seamless background refreshes without displaying loading indicators to users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->