### PR TITLE
feat: Calendar Settings

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -331,7 +331,9 @@ function HomeContent() {
         onSelectCalendar={setSelectedCalendar}
         onSelectPreset={setSelectedPresetId}
         onCreateCalendar={() => dialogStates.setShowCalendarDialog(true)}
-        onManagePassword={() => dialogStates.setShowManagePasswordDialog(true)}
+        onManagePassword={() =>
+          dialogStates.setShowCalendarSettingsDialog(true)
+        }
         onDeleteCalendar={initiateDeleteCalendar}
         onExternalSync={handleExternalSyncClick}
         onSyncNotifications={handleSyncNotifications}
@@ -440,9 +442,11 @@ function HomeContent() {
         onPasswordDialogChange={dialogStates.setShowPasswordDialog}
         calendars={calendars}
         onPasswordSuccess={handlePasswordSuccess}
-        showManagePasswordDialog={dialogStates.showManagePasswordDialog}
-        onManagePasswordDialogChange={dialogStates.setShowManagePasswordDialog}
-        onManagePasswordSuccess={refetchCalendars}
+        showCalendarSettingsDialog={dialogStates.showCalendarSettingsDialog}
+        onCalendarSettingsDialogChange={
+          dialogStates.setShowCalendarSettingsDialog
+        }
+        onCalendarSettingsSuccess={refetchCalendars}
         showDeleteCalendarDialog={dialogStates.showDeleteCalendarDialog}
         onDeleteCalendarDialogChange={dialogStates.setShowDeleteCalendarDialog}
         calendarToDelete={dialogStates.calendarToDelete}

--- a/components/calendar-dialog.tsx
+++ b/components/calendar-dialog.tsx
@@ -61,7 +61,7 @@ export function CalendarDialog({
 
     // Can't lock without password
     if (lockCalendar && !usePassword) {
-      setError(t("password.lockRequiresPassword"));
+      setError(t("calendar.lockRequiresPassword"));
       return;
     }
 
@@ -218,10 +218,10 @@ export function CalendarDialog({
                       htmlFor="lockCalendar"
                       className="text-sm font-medium cursor-pointer"
                     >
-                      {t("password.lockCalendar")}
+                      {t("calendar.lockCalendar")}
                     </Label>
                     <p className="text-xs text-muted-foreground mt-0.5">
-                      {t("password.lockCalendarHint")}
+                      {t("calendar.lockCalendarHint")}
                     </p>
                   </div>
                 </div>

--- a/components/calendar-selector.tsx
+++ b/components/calendar-selector.tsx
@@ -10,7 +10,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Button } from "@/components/ui/button";
-import { Plus, KeyRound, Trash2, Cloud, Bell } from "lucide-react";
+import { Plus, CalendarCog, Trash2, Cloud, Bell } from "lucide-react";
 import { getCachedPassword } from "@/lib/password-cache";
 
 interface CalendarSelectorProps {
@@ -74,9 +74,11 @@ export function CalendarSelector({
             size="icon"
             variant="outline"
             className="h-9 w-9 sm:h-10 sm:w-10"
-            title={t("calendar.managePassword")}
+            title={t("calendar.settings", {
+              name: selectedCalendar?.name || "",
+            })}
           >
-            <KeyRound className="h-4 w-4" />
+            <CalendarCog className="h-4 w-4" />
           </Button>
         )}
         {onExternalSync && selectedId && !shouldHideSyncButtons && (
@@ -167,9 +169,11 @@ export function CalendarSelector({
               size="sm"
               variant="outline"
               className="h-9"
-              title={t("calendar.managePassword")}
+              title={t("calendar.settings", {
+                name: selectedCalendar?.name || "",
+              })}
             >
-              <KeyRound className="h-4 w-4" />
+              <CalendarCog className="h-4 w-4" />
             </Button>
           )}
           {onExternalSync && !shouldHideSyncButtons && (

--- a/components/dialog-manager.tsx
+++ b/components/dialog-manager.tsx
@@ -1,7 +1,7 @@
 import { CalendarDialog } from "@/components/calendar-dialog";
 import { ShiftDialog, ShiftFormData } from "@/components/shift-dialog";
 import { PasswordDialog } from "@/components/password-dialog";
-import { ManagePasswordDialog } from "@/components/manage-password-dialog";
+import { CalendarSettingsDialog } from "@/components/calendar-settings-dialog";
 import { DeleteCalendarDialog } from "@/components/delete-calendar-dialog";
 import { ExternalSyncManageDialog } from "@/components/external-sync-manage-dialog";
 import { SyncNotificationDialog } from "@/components/sync-notification-dialog";
@@ -36,10 +36,10 @@ interface DialogManagerProps {
   calendars: CalendarWithCount[];
   onPasswordSuccess: (password: string) => void;
 
-  // Manage Password Dialog
-  showManagePasswordDialog: boolean;
-  onManagePasswordDialogChange: (open: boolean) => void;
-  onManagePasswordSuccess: () => void;
+  // Calendar Settings Dialog
+  showCalendarSettingsDialog: boolean;
+  onCalendarSettingsDialogChange: (open: boolean) => void;
+  onCalendarSettingsSuccess: () => void;
 
   // Delete Calendar Dialog
   showDeleteCalendarDialog: boolean;
@@ -136,13 +136,17 @@ export function DialogManager(props: DialogManagerProps) {
             onSuccess={props.onPasswordSuccess}
           />
 
-          <ManagePasswordDialog
-            open={props.showManagePasswordDialog}
-            onOpenChange={props.onManagePasswordDialogChange}
+          <CalendarSettingsDialog
+            open={props.showCalendarSettingsDialog}
+            onOpenChange={props.onCalendarSettingsDialogChange}
             calendarId={props.selectedCalendar}
             calendarName={
               props.calendars.find((c) => c.id === props.selectedCalendar)
                 ?.name || ""
+            }
+            calendarColor={
+              props.calendars.find((c) => c.id === props.selectedCalendar)
+                ?.color || "#3b82f6"
             }
             hasPassword={
               !!props.calendars.find((c) => c.id === props.selectedCalendar)
@@ -152,7 +156,7 @@ export function DialogManager(props: DialogManagerProps) {
               props.calendars.find((c) => c.id === props.selectedCalendar)
                 ?.isLocked || false
             }
-            onSuccess={props.onManagePasswordSuccess}
+            onSuccess={props.onCalendarSettingsSuccess}
           />
 
           <ExternalSyncManageDialog

--- a/hooks/useDialogStates.ts
+++ b/hooks/useDialogStates.ts
@@ -5,7 +5,7 @@ export function useDialogStates() {
   const [showCalendarDialog, setShowCalendarDialog] = useState(false);
   const [showShiftDialog, setShowShiftDialog] = useState(false);
   const [showPasswordDialog, setShowPasswordDialog] = useState(false);
-  const [showManagePasswordDialog, setShowManagePasswordDialog] =
+  const [showCalendarSettingsDialog, setShowCalendarSettingsDialog] =
     useState(false);
   const [showMobileCalendarDialog, setShowMobileCalendarDialog] =
     useState(false);
@@ -36,8 +36,8 @@ export function useDialogStates() {
     setShowShiftDialog,
     showPasswordDialog,
     setShowPasswordDialog,
-    showManagePasswordDialog,
-    setShowManagePasswordDialog,
+    showCalendarSettingsDialog,
+    setShowCalendarSettingsDialog,
     showMobileCalendarDialog,
     setShowMobileCalendarDialog,
     showDeleteCalendarDialog,

--- a/messages/de.json
+++ b/messages/de.json
@@ -60,7 +60,13 @@
     "select": "Dein BetterShift Kalender",
     "deleteCalendar": "Kalender löschen",
     "deleteWarning": "Alle Schichten, Presets und Notizen werden ebenfalls gelöscht.",
-    "managePassword": "Passwort verwalten"
+    "managePassword": "Passwort verwalten",
+    "settings": "Kalendereinstellungen für \"{name}\"",
+    "settingsDescription": "Passe Name, Farbe und Passwortschutz an",
+    "currentlyProtected": "Dieser Kalender ist derzeit passwortgeschützt.",
+    "lockCalendar": "Kalender komplett sperren",
+    "lockCalendarHint": "Sperrt Kalender komplett - Passwort zum sehen und verwalten erforderlich",
+    "lockRequiresPassword": "Kalendersperre erfordert ein Passwort"
   },
   "color": {
     "custom": "Eigene Farbe",
@@ -79,11 +85,6 @@
     "manage": "Passwort für \"{name}\" verwalten",
     "enter": "Passwort für \"{name}\" eingeben",
     "enterCalendarPassword": "Kalenderpasswort eingeben",
-    "currentlyProtected": "Dieser Kalender ist derzeit passwortgeschützt.",
-    "notProtected": "Dieser Kalender ist derzeit nicht passwortgeschützt.",
-    "lockCalendar": "Kalender komplett sperren",
-    "lockCalendarHint": "Sperrt Kalender komplett - Passwort zum sehen und verwalten erforderlich",
-    "lockRequiresPassword": "Kalendersperre erfordert ein Passwort",
     "currentlyLocked": "Dieser Kalender ist derzeit gesperrt.",
     "unlockRequired": "Kalender ist passwortgeschützt",
     "unlockRequiredDescription": "Dieser Kalender ist passwortgeschützt. Bitte entsperre den Kalender, um Vorlagen zu verwalten und Schichten zu erstellen.",

--- a/messages/en.json
+++ b/messages/en.json
@@ -60,7 +60,13 @@
     "select": "Your BetterShift Calendar",
     "deleteCalendar": "Delete Calendar",
     "deleteWarning": "All shifts, presets and notes will also be deleted.",
-    "managePassword": "Manage Password"
+    "managePassword": "Manage Password",
+    "settings": "Calendar Settings for \"{name}\"",
+    "settingsDescription": "Customize name, color and password protection",
+    "currentlyProtected": "This calendar is currently password protected.",
+    "lockCalendar": "Lock calendar completely",
+    "lockCalendarHint": "Locks calendar completely - password required to view and manage",
+    "lockRequiresPassword": "Locking the calendar requires a password"
   },
   "color": {
     "custom": "Custom",
@@ -79,11 +85,6 @@
     "manage": "Manage Password for \"{name}\"",
     "enter": "Enter Password for \"{name}\"",
     "enterCalendarPassword": "Enter calendar password",
-    "currentlyProtected": "This calendar is currently password protected.",
-    "notProtected": "This calendar is currently not password protected.",
-    "lockCalendar": "Lock calendar completely",
-    "lockCalendarHint": "Locks calendar completely - password required to view and manage",
-    "lockRequiresPassword": "Locking the calendar requires a password",
     "currentlyLocked": "This calendar is currently locked.",
     "unlockRequired": "Calendar is password protected",
     "unlockRequiredDescription": "This calendar is password protected. Please unlock the calendar to manage presets and create shifts.",

--- a/messages/it.json
+++ b/messages/it.json
@@ -60,7 +60,13 @@
     "select": "Il tuo Calendario BetterShift",
     "deleteCalendar": "Elimina Calendario",
     "deleteWarning": "Anche tutti i turni, i preset e le note verranno eliminati.",
-    "managePassword": "Gestisci Password"
+    "managePassword": "Gestisci Password",
+    "settings": "Impostazioni Calendario per \"{name}\"",
+    "settingsDescription": "Personalizza nome, colore e protezione password",
+    "currentlyProtected": "Questo calendario è attualmente protetto da password.",
+    "lockCalendar": "Blocca calendario completamente",
+    "lockCalendarHint": "Blocca il calendario completamente - è necessaria la password per visualizzare e gestire",
+    "lockRequiresPassword": "Il blocco del calendario richiede una password"
   },
   "color": {
     "custom": "Personalizzato",
@@ -79,11 +85,6 @@
     "manage": "Gestisci Password per \"{name}\"",
     "enter": "Inserisci Password per \"{name}\"",
     "enterCalendarPassword": "Inserisci la password del calendario",
-    "currentlyProtected": "Questo calendario è attualmente protetto da password.",
-    "notProtected": "Questo calendario non è attualmente protetto da password.",
-    "lockCalendar": "Blocca calendario completamente",
-    "lockCalendarHint": "Blocca il calendario completamente - è necessaria la password per visualizzare e gestire",
-    "lockRequiresPassword": "Il blocco del calendario richiede una password",
     "currentlyLocked": "Questo calendario è attualmente bloccato.",
     "unlockRequired": "Il calendario è protetto da password",
     "unlockRequiredDescription": "Questo calendario è protetto da password. Sblocca il calendario per gestire i preset e creare turni.",


### PR DESCRIPTION
Replace the separate manage-password workflow with a unified calendar settings dialog to centralize name, color and password/lock management.

Updates dialog state and handlers to use calendar settings semantics, swaps password icon/tooltip for a settings icon, and removes the old manage-password component. Moves localization keys from the password namespace into calendar-specific keys and adds new strings for locking behavior. This simplifies UI/UX around calendar configuration and prevents mismatched dialog/state names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Calendar settings dialog now allows customization of calendar name and color alongside password protection in a unified interface.

* **Improvements**
  * Updated calendar settings icon and reorganized the management interface for a more cohesive user experience.
  * Enhanced multilingual support with updated translations across supported languages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->