### PR TITLE
feat: Adds option to hide preset header

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -338,6 +338,8 @@ function HomeContent() {
         onMobileCalendarDialogChange={dialogStates.setShowMobileCalendarDialog}
         onViewSettingsClick={() => dialogStates.setShowViewSettingsDialog(true)}
         presetsLoading={presetsLoading && !isSelectedCalendarLocked}
+        hidePresetHeader={viewSettings.hidePresetHeader}
+        onHidePresetHeaderChange={viewSettings.handleHidePresetHeaderChange}
       />
 
       <div className="container max-w-4xl mx-auto px-1 py-3 sm:p-4 flex-1">

--- a/components/app-header.tsx
+++ b/components/app-header.tsx
@@ -45,6 +45,8 @@ interface AppHeaderProps {
   onMobileCalendarDialogChange: (open: boolean) => void;
   onViewSettingsClick: () => void;
   presetsLoading?: boolean;
+  hidePresetHeader?: boolean;
+  onHidePresetHeaderChange?: (hide: boolean) => void;
 }
 
 export function AppHeader({
@@ -69,6 +71,8 @@ export function AppHeader({
   onMobileCalendarDialogChange,
   onViewSettingsClick,
   presetsLoading = false,
+  hidePresetHeader = false,
+  onHidePresetHeaderChange,
 }: AppHeaderProps) {
   const t = useTranslations();
   const locale = useLocale();
@@ -279,6 +283,8 @@ export function AppHeader({
                   onPasswordRequired={onPasswordRequired}
                   onViewSettingsClick={onViewSettingsClick}
                   loading={presetsLoading}
+                  hidePresetHeader={hidePresetHeader}
+                  onHidePresetHeaderChange={onHidePresetHeaderChange}
                 />
               </div>
             )}

--- a/components/preset-list-skeleton.tsx
+++ b/components/preset-list-skeleton.tsx
@@ -1,13 +1,31 @@
 import { Skeleton } from "@/components/ui/skeleton";
 
-export function PresetListSkeleton() {
+interface PresetListSkeletonProps {
+  hidePresetHeader?: boolean;
+}
+
+export function PresetListSkeleton({
+  hidePresetHeader = false,
+}: PresetListSkeletonProps) {
   return (
-    <div className="flex flex-wrap gap-2">
-      <Skeleton className="h-9 w-24 rounded-lg" />
-      <Skeleton className="h-9 w-32 rounded-lg" />
-      <Skeleton className="h-9 w-28 rounded-lg" />
-      <Skeleton className="h-9 w-36 rounded-lg" />
-      <Skeleton className="h-9 w-9 rounded-lg" />
+    <div className="space-y-2">
+      {/* Preset Buttons Row */}
+      {!hidePresetHeader && (
+        <div className="flex flex-wrap gap-2">
+          <Skeleton className="h-9 w-24 rounded-full" />
+          <Skeleton className="h-9 w-32 rounded-full" />
+          <Skeleton className="h-9 w-28 rounded-full" />
+          <Skeleton className="h-9 w-36 rounded-full" />
+        </div>
+      )}
+
+      {/* Control Buttons Row */}
+      <div className="flex items-center gap-2">
+        {!hidePresetHeader && <Skeleton className="h-9 w-9 rounded-lg" />}
+        <div className="flex-1" />
+        <Skeleton className="h-9 w-9 rounded-lg" />
+        <Skeleton className="h-9 w-9 rounded-lg" />
+      </div>
     </div>
   );
 }

--- a/components/preset-list.tsx
+++ b/components/preset-list.tsx
@@ -25,6 +25,8 @@ interface PresetListProps {
   onViewSettingsClick?: () => void;
   onUnlock?: () => void;
   loading?: boolean;
+  hidePresetHeader?: boolean;
+  onHidePresetHeaderChange?: (hide: boolean) => void;
 }
 
 export function PresetList({
@@ -37,6 +39,8 @@ export function PresetList({
   onViewSettingsClick,
   onUnlock,
   loading = false,
+  hidePresetHeader = false,
+  onHidePresetHeaderChange,
 }: PresetListProps) {
   const t = useTranslations();
   const [showSecondary, setShowSecondary] = React.useState(false);
@@ -54,7 +58,7 @@ export function PresetList({
 
   // Show loading state while fetching
   if (loading) {
-    return <PresetListSkeleton />;
+    return <PresetListSkeleton hidePresetHeader={hidePresetHeader} />;
   }
 
   // Show unlock hint if calendar requires password and no password is cached (but not locked)
@@ -139,49 +143,27 @@ export function PresetList({
   }
 
   return (
-    <div className="space-y-3">
-      {/* Primary Presets */}
-      <div className="flex items-center gap-1.5 sm:gap-2 flex-wrap">
-        {primaryPresets.map((preset) => (
-          <PresetButton
-            key={preset.id}
-            preset={preset}
-            isSelected={selectedPresetId === preset.id}
-            onSelect={() =>
-              onSelectPreset(
-                selectedPresetId === preset.id ? undefined : preset.id
-              )
-            }
-          />
-        ))}
-        <Button
-          variant="outline"
-          size="sm"
-          onClick={onManageClick}
-          disabled={!onManageClick}
-          className="gap-1.5 text-xs sm:text-sm px-2.5 sm:px-4 h-8 sm:h-9 border-primary/30 hover:border-primary/50 hover:bg-primary/5"
-          title={t("preset.manage")}
-        >
-          <Settings className="h-3.5 sm:h-4 w-3.5 sm:w-4" />
-        </Button>
-        {onViewSettingsClick && (
-          <>
-            <div className="flex-1" />
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={onViewSettingsClick}
-              className="gap-1.5 text-xs sm:text-sm px-2.5 sm:px-4 h-8 sm:h-9 border-primary/30 hover:border-primary/50 hover:bg-primary/5"
-              title={t("view.settingsTitle")}
-            >
-              <Settings2 className="h-3.5 sm:h-4 w-3.5 sm:w-4" />
-            </Button>
-          </>
-        )}
-      </div>
+    <div className="space-y-2">
+      {/* Preset Buttons Row */}
+      {!hidePresetHeader && (
+        <div className="flex items-center gap-1.5 sm:gap-2 flex-wrap">
+          {primaryPresets.map((preset) => (
+            <PresetButton
+              key={preset.id}
+              preset={preset}
+              isSelected={selectedPresetId === preset.id}
+              onSelect={() =>
+                onSelectPreset(
+                  selectedPresetId === preset.id ? undefined : preset.id
+                )
+              }
+            />
+          ))}
+        </div>
+      )}
 
       {/* Secondary Presets - Collapsible */}
-      {secondaryPresets.length > 0 && (
+      {!hidePresetHeader && secondaryPresets.length > 0 && (
         <div className="space-y-1.5">
           <Button
             variant="ghost"
@@ -217,6 +199,53 @@ export function PresetList({
           )}
         </div>
       )}
+
+      {/* Control Buttons Row */}
+      <div className="flex items-center gap-1.5 sm:gap-2">
+        {!hidePresetHeader && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onManageClick}
+            disabled={!onManageClick}
+            className="gap-1.5 text-xs sm:text-sm px-2.5 sm:px-4 h-8 sm:h-9 border-primary/30 hover:border-primary/50 hover:bg-primary/5"
+            title={t("preset.manage")}
+          >
+            <Settings className="h-3.5 sm:h-4 w-3.5 sm:w-4" />
+          </Button>
+        )}
+        <div className="flex-1" />
+        {onViewSettingsClick && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onViewSettingsClick}
+            className="gap-1.5 text-xs sm:text-sm px-2.5 sm:px-4 h-8 sm:h-9 border-primary/30 hover:border-primary/50 hover:bg-primary/5"
+            title={t("view.settingsTitle")}
+          >
+            <Settings2 className="h-3.5 sm:h-4 w-3.5 sm:w-4" />
+          </Button>
+        )}
+        {onHidePresetHeaderChange && (
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => onHidePresetHeaderChange(!hidePresetHeader)}
+            className="h-8 sm:h-9 w-8 sm:w-9 p-0 text-muted-foreground hover:text-foreground"
+            title={
+              hidePresetHeader
+                ? t("preset.showPresets")
+                : t("preset.hidePresets")
+            }
+          >
+            {hidePresetHeader ? (
+              <ChevronDown className="h-4 w-4" />
+            ) : (
+              <ChevronUp className="h-4 w-4" />
+            )}
+          </Button>
+        )}
+      </div>
     </div>
   );
 }

--- a/components/preset-selector.tsx
+++ b/components/preset-selector.tsx
@@ -19,6 +19,8 @@ interface PresetSelectorProps {
   onPasswordRequired: (action: () => Promise<void>) => void;
   onViewSettingsClick?: () => void;
   loading?: boolean;
+  hidePresetHeader?: boolean;
+  onHidePresetHeaderChange?: (hide: boolean) => void;
 }
 
 export function PresetSelector({
@@ -33,6 +35,8 @@ export function PresetSelector({
   onPasswordRequired,
   onViewSettingsClick,
   loading = false,
+  hidePresetHeader = false,
+  onHidePresetHeaderChange,
 }: PresetSelectorProps) {
   const [showManageDialog, setShowManageDialog] = useState(false);
 
@@ -66,6 +70,8 @@ export function PresetSelector({
         onViewSettingsClick={onViewSettingsClick}
         onUnlock={() => onPasswordRequired(async () => {})}
         loading={loading}
+        hidePresetHeader={hidePresetHeader}
+        onHidePresetHeaderChange={onHidePresetHeaderChange}
       />
 
       <PresetManageDialog

--- a/hooks/useViewSettings.ts
+++ b/hooks/useViewSettings.ts
@@ -77,6 +77,14 @@ export function useViewSettings() {
     return false;
   });
 
+  const [hidePresetHeader, setHidePresetHeader] = useState<boolean>(() => {
+    if (typeof window !== "undefined") {
+      const stored = localStorage.getItem("hide-preset-header");
+      return stored === "true";
+    }
+    return false;
+  });
+
   const handleShiftsPerDayChange = useCallback((count: number | null) => {
     setShiftsPerDay(count);
     if (typeof window !== "undefined") {
@@ -138,6 +146,13 @@ export function useViewSettings() {
     }
   }, []);
 
+  const handleHidePresetHeaderChange = useCallback((hide: boolean) => {
+    setHidePresetHeader(hide);
+    if (typeof window !== "undefined") {
+      localStorage.setItem("hide-preset-header", hide.toString());
+    }
+  }, []);
+
   return {
     shiftsPerDay,
     externalShiftsPerDay,
@@ -146,6 +161,7 @@ export function useViewSettings() {
     shiftSortType,
     shiftSortOrder,
     combinedSortMode,
+    hidePresetHeader,
     handleShiftsPerDayChange,
     handleExternalShiftsPerDayChange,
     handleShowShiftNotesChange,
@@ -153,5 +169,6 @@ export function useViewSettings() {
     handleShiftSortTypeChange,
     handleShiftSortOrderChange,
     handleCombinedSortModeChange,
+    handleHidePresetHeaderChange,
   };
 }

--- a/messages/de.json
+++ b/messages/de.json
@@ -138,6 +138,8 @@
     "markAsSecondary": "Als sekundär markieren (standardmäßig eingeklappt)",
     "hideFromStats": "Aus Statistik ausblenden",
     "hideFromStatsHint": "Schichten dieser Vorlage aus der Statistik ausschließen",
+    "showPresets": "Vorlagen anzeigen",
+    "hidePresets": "Vorlagen ausblenden",
     "hiddenFromStats": "Aus Statistik ausgeblendet"
   },
   "calendar_grid": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -138,6 +138,8 @@
     "markAsSecondary": "Mark as secondary (collapsed by default)",
     "hideFromStats": "Hide from statistics",
     "hideFromStatsHint": "Exclude shifts from this preset from statistics",
+    "showPresets": "Show presets",
+    "hidePresets": "Hide presets",
     "hiddenFromStats": "Hidden from statistics"
   },
   "calendar_grid": {

--- a/messages/it.json
+++ b/messages/it.json
@@ -138,7 +138,9 @@
     "markAsSecondary": "Segna come secondario (compresso di default)",
     "hideFromStats": "Nascondi dalle statistiche",
     "hideFromStatsHint": "Escludi i turni da questo preset dalle statistiche",
-    "hiddenFromStats": "Nascosto dalle statistiche"
+    "hiddenFromStats": "Nascosto dalle statistiche",
+    "showPresets": "Mostra preset",
+    "hidePresets": "Nascondi preset"
   },
   "calendar_grid": {
     "monday": "Lun",


### PR DESCRIPTION
Adds a toggle to hide the preset header in the presets UI and exposes a handler to control it.

Persists the user's preference in localStorage so the header visibility is remembered across sessions. Updates the preset list, skeleton, selector and header to respect the hide/show state and adds a small control button to toggle visibility. Also adds i18n strings for show/hide labels.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Users can now toggle the preset header visibility on and off to customize their interface layout.
  * Preset header visibility preferences are automatically saved to browser storage and restored on subsequent visits.
  * Added localization support for the new preset visibility toggle in multiple languages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->