### PR TITLE
chore!: cut Docker image from 1.01GB to 203MB and drop ARM builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 # dependencies
-node_modules
+# **/ because Docker matches the whole relative path: a bare "node_modules"
+# excludes the root one only.
+**/node_modules
 .pnp
 .pnp.*
 
@@ -7,7 +9,7 @@ node_modules
 coverage
 
 # next.js
-.next/
+**/.next/
 out/
 build
 
@@ -47,6 +49,10 @@ data/
 .gitignore
 .github
 
+# Agent worktrees: gitignored, so CI never sends them -- a local build does.
+.claude
+.LOCAL
+
 # IDE
 .vscode
 .idea
@@ -55,7 +61,5 @@ data/
 docker-compose.override.yml
 
 # misc
-README.md
 *.md
-test-changelog.sh
 LICENSE

--- a/.github/workflows/docker-dev.yml
+++ b/.github/workflows/docker-dev.yml
@@ -7,6 +7,12 @@ on:
   pull_request:
     branches:
       - main
+    # The image content of a translations- or docs-only PR is covered by the
+    # main build.
+    paths-ignore:
+      - "messages/**"
+      - "docs/**"
+      - "**/*.md"
 
 permissions:
   contents: read
@@ -24,9 +30,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -55,15 +58,21 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          # Fork PRs get a read-only GITHUB_TOKEN and cannot push to ghcr.io, so they
-          # only run the multi-arch build as a check. Pushes to main and PRs from
+          # Fork PRs get a read-only GITHUB_TOKEN and cannot push to ghcr.io, so
+          # they only run the build as a check. Pushes to main and PRs from
           # branches in this repository publish their image (dev / pr-<number>).
           push: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # Only write the cache on main. Actions caches are scoped per ref, so a
+          # PR's export is never read back, and mode=max on a PR evicts main's
+          # entry from the 10 GB budget -- ~5.5 min of export per PR run.
+          cache-to: ${{ github.event_name == 'push' && 'type=gha,mode=max' || '' }}
+          # No consumer for provenance/SBOM on a dev image, and it adds the
+          # unknown/unknown entries in the ghcr tag list.
+          provenance: false
           build-args: |
             VERSION=dev
             BUILD_DATE=${{ steps.timestamp.outputs.BUILD_DATE }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ permissions:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   # Never cancel an in-progress release build: a half-cancelled run could
-  # publish a broken or partial multi-arch image and/or GitHub release.
+  # publish a broken or partial image and/or GitHub release.
   cancel-in-progress: false
 
 jobs:
@@ -86,36 +86,45 @@ jobs:
           # Build changelog with grouping
           CHANGELOG=""
 
+          # Breaking changes: conventional commits mark these with a `!` before
+          # the colon (feat!:, chore(docker)!:). Listed first and also under their
+          # own type below, so an upgrade note is never buried in a long list.
+          BREAKING=$(echo "$ALL_COMMITS" | grep -E "^[a-z]+(\([^)]*\))?!:" | sed 's/|/ /' | sed 's/^/- /' || true)
+          if [ -n "$BREAKING" ]; then
+            CHANGELOG+="### ⚠️ Breaking Changes"$'\n\n'
+            CHANGELOG+="$BREAKING"$'\n\n'
+          fi
+
           # Features
-          FEATURES=$(echo "$ALL_COMMITS" | grep "^feat:" | sed 's/|/ /' | sed 's/^/- /' || true)
+          FEATURES=$(echo "$ALL_COMMITS" | grep -E "^feat(\([^)]*\))?!?:" | sed 's/|/ /' | sed 's/^/- /' || true)
           if [ -n "$FEATURES" ]; then
             CHANGELOG+="### ✨ Features"$'\n\n'
             CHANGELOG+="$FEATURES"$'\n\n'
           fi
 
           # Bug Fixes
-          FIXES=$(echo "$ALL_COMMITS" | grep "^fix:" | sed 's/|/ /' | sed 's/^/- /' || true)
+          FIXES=$(echo "$ALL_COMMITS" | grep -E "^fix(\([^)]*\))?!?:" | sed 's/|/ /' | sed 's/^/- /' || true)
           if [ -n "$FIXES" ]; then
             CHANGELOG+="### 🐛 Bug Fixes"$'\n\n'
             CHANGELOG+="$FIXES"$'\n\n'
           fi
 
           # Documentation
-          DOCS=$(echo "$ALL_COMMITS" | grep "^docs:" | sed 's/|/ /' | sed 's/^/- /' || true)
+          DOCS=$(echo "$ALL_COMMITS" | grep -E "^docs(\([^)]*\))?!?:" | sed 's/|/ /' | sed 's/^/- /' || true)
           if [ -n "$DOCS" ]; then
             CHANGELOG+="### 📝 Documentation"$'\n\n'
             CHANGELOG+="$DOCS"$'\n\n'
           fi
 
           # Chores
-          CHORES=$(echo "$ALL_COMMITS" | grep "^chore:" | sed 's/|/ /' | sed 's/^/- /' || true)
+          CHORES=$(echo "$ALL_COMMITS" | grep -E "^chore(\([^)]*\))?!?:" | sed 's/|/ /' | sed 's/^/- /' || true)
           if [ -n "$CHORES" ]; then
             CHANGELOG+="### 🔧 Chores"$'\n\n'
             CHANGELOG+="$CHORES"$'\n\n'
           fi
 
           # Other changes (not matching conventional commits)
-          OTHERS=$(echo "$ALL_COMMITS" | grep -vE "^(feat|fix|docs|chore):" | sed 's/|/ /' | sed 's/^/- /' || true)
+          OTHERS=$(echo "$ALL_COMMITS" | grep -vE "^(feat|fix|docs|chore)(\([^)]*\))?!?:" | sed 's/|/ /' | sed 's/^/- /' || true)
           if [ -n "$OTHERS" ]; then
             CHANGELOG+="### 🔀 Other Changes"$'\n\n'
             CHANGELOG+="$OTHERS"$'\n\n'
@@ -130,9 +139,6 @@ jobs:
 
           # Set previous tag
           echo "previous_tag=$PREVIOUS_TAG" >> $GITHUB_OUTPUT
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -164,7 +170,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,23 +32,15 @@ ENV NODE_ENV=production
 RUN --mount=type=cache,target=/app/.next/cache \
     npm run build
 
-# Stage 3: Production dependencies
-FROM node:24-alpine AS prod-deps
-RUN apk add --no-cache libc6-compat
-WORKDIR /app
+# drizzle-orm is the only runtime dependency outside the standalone trace; the
+# migrator needs it as a real module. Pruned here, not in the runner: deleting
+# in a later stage only writes whiteouts over layers already built and pushed.
+RUN find /app/node_modules/drizzle-orm \
+        \( -name '*.map' -o -name '*.d.ts' -o -name '*.d.cts' \) -delete
 
-# Copy package files
-COPY package.json package-lock.json ./
-
-# Install only production dependencies
-RUN --mount=type=cache,target=/root/.npm-prod \
-    npm ci --omit=dev --cache /root/.npm-prod && \
-    npm cache clean --force
-
-# Stage 4: Runner
+# Stage 3: Runner
 FROM node:24-alpine AS runner
-# su-exec lets the entrypoint drop from root back to the unprivileged
-# "node" user after fixing bind-mount ownership (see docker-entrypoint.sh).
+# su-exec: see docker-entrypoint.sh.
 RUN apk add --no-cache libc6-compat dumb-init su-exec
 WORKDIR /app
 
@@ -57,9 +49,8 @@ ARG VERSION=dev
 ARG BUILD_DATE=unknown
 ARG COMMIT_SHA=unknown
 ARG COMMIT_REF=unknown
-# Promote the build ARGs to ENV so the `node -e` RUN below can actually see
-# them -- a plain ARG is not exposed to a RUN command's process env, so
-# without this the build metadata below was always written as empty strings.
+# ARG is not visible to a RUN command's process env; without these the build
+# metadata below is written as empty strings.
 ENV VERSION=$VERSION
 ENV BUILD_DATE=$BUILD_DATE
 ENV COMMIT_SHA=$COMMIT_SHA
@@ -68,12 +59,9 @@ ENV COMMIT_REF=$COMMIT_REF
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
-# The standalone server binds to $HOSTNAME, and Docker always sets HOSTNAME to
-# the container id. Without this default it binds to that name only, so 127.0.0.1
-# inside the container is unbound and the HEALTHCHECK below can never pass --
-# the container is reported unhealthy even though it serves traffic fine.
-# docker-compose.yml happens to supply HOSTNAME=0.0.0.0 through env_file, but a
-# plain `docker run` does not. A runtime -e still overrides this.
+# Docker sets HOSTNAME to the container id and the standalone server binds to
+# it, leaving 127.0.0.1 unbound so the HEALTHCHECK can never pass. A runtime
+# -e still overrides this.
 ENV HOSTNAME=0.0.0.0
 ENV PORT=3000
 
@@ -81,29 +69,18 @@ ENV PORT=3000
 COPY --from=builder /app/.next/standalone ./
 COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/public ./public
-COPY --from=builder /app/drizzle ./drizzle
-COPY --from=builder /app/lib ./lib
 COPY --from=builder /app/package.json ./package.json
-COPY --from=builder /app/drizzle.config.ts ./drizzle.config.ts
 
-# Copy production dependencies. Required even though the standalone output
-# already bundles its own node_modules: CMD runs `npm run db:migrate`,
-# which needs drizzle-kit, and drizzle-kit is not part of the standalone
-# trace. Do not remove this stage/copy -- doing so breaks migrations on
-# every container start.
-COPY --from=prod-deps /app/node_modules ./node_modules
+COPY --from=builder /app/drizzle ./drizzle
+COPY --from=builder /app/scripts/migrate.mjs ./scripts/migrate.mjs
+COPY --from=builder /app/lib/db/db-path.mjs ./lib/db/db-path.mjs
+COPY --from=builder /app/node_modules/drizzle-orm ./node_modules/drizzle-orm
 
 COPY docker-entrypoint.sh /app/docker-entrypoint.sh
 RUN chmod +x /app/docker-entrypoint.sh
 
-# The writable paths, handed to the unprivileged user at build time. This has
-# to come after the COPY of ./public, which would otherwise put a root-owned
-# uploads directory back. Giving them away here is what lets the image run
-# under an explicit `docker run --user node` with no privileged repair step.
-# A bind mount overrides all of it with the host's ownership: as root the
-# entrypoint chowns that at startup, while an explicit non-root user needs the
-# host directory to be writable for that uid -- nothing in the container can
-# fix it from the inside.
+# Must stay after the COPY of ./public, which would otherwise restore a
+# root-owned uploads directory. Lets `docker run --user node` work unrepaired.
 RUN mkdir -p /app/data /app/public/uploads \
     && chown -R node:node /app/data /app/public/uploads
 
@@ -117,13 +94,9 @@ EXPOSE 3000
 HEALTHCHECK --interval=30s --timeout=10s --start-period=40s --retries=3 \
     CMD node -e "require('http').get('http://localhost:3000/api/health', (r) => {let d='';r.on('data',c=>d+=c);r.on('end',()=>process.exit(r.statusCode===200?0:1))}).on('error',()=>process.exit(1))"
 
-# dumb-init stays PID 1 for correct signal handling; it hands off to the
-# entrypoint, which fixes bind-mount ownership as root and then drops
-# privileges to the unprivileged "node" user before running CMD. A plain
-# `USER node` is not safe here: existing deployments have a root-owned
-# ./data bind mount from earlier root-run images, and the container would
-# no longer be able to write its own database after upgrading.
+# dumb-init stays PID 1 for signal handling; see docker-entrypoint.sh for why
+# this is not a plain `USER node`.
 ENTRYPOINT ["/usr/bin/dumb-init", "--", "/app/docker-entrypoint.sh"]
 
 # Start with migration, then server
-CMD ["sh", "-c", "npm run db:migrate && node server.js"]
+CMD ["sh", "-c", "node scripts/migrate.mjs && node server.js"]

--- a/README.md
+++ b/README.md
@@ -145,6 +145,13 @@ Images are available at `ghcr.io/pantelx/bettershift`:
 | `vX.Y.Z` | Specific version             |
 | `dev`    | Development build (unstable) |
 
+> [!IMPORTANT]
+> **Platform support: `linux/amd64` only.**
+> Releases up to and including `v2.2.1` were also published for `linux/arm64`.
+> Starting with `v3.0.0`, ARM images are no longer built — running BetterShift
+> on ARM hardware (Raspberry Pi, Ampere, Apple Silicon) requires pinning to
+> `v2.2.1`, which will not receive further updates.
+
 ## Tech Stack
 
 | Layer     | Technology                        |

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,22 +1,12 @@
 #!/bin/sh
-# Entrypoint for the runner stage: fixes ownership of writable, bind-mounted
-# paths and then drops from root to the unprivileged "node" user before
-# exec'ing the real command. This exists instead of a plain `USER node`
-# directive because existing self-hosted deployments bind-mount ./data
-# (and, since the uploads volume was added, ./data/uploads) from the host,
-# where it is commonly root-owned from earlier root-run images. A bare
-# `USER node` would leave the container unable to write its own database on
-# upgrade. Running as root here only long enough to chown, then dropping
-# privileges via su-exec, keeps upgrades working while the app itself still
-# runs unprivileged.
+# Chowns the writable paths, then drops root to "node" via su-exec.
+# Not a plain `USER node`: existing deployments bind-mount a ./data that earlier
+# root-run images left root-owned, which the container could then not write.
+
 set -e
 
-# When the container is started with an explicit user (`docker run --user`,
-# compose `user:`), there is nothing to drop to and no privilege to chown
-# with: su-exec would still attempt the identity-changing syscalls and abort
-# before the app ever starts. The image ships both paths owned by "node", so
-# that user needs no repair here; any other uid, or a bind mount the host has
-# not made writable for it, has to be sorted out on the host side.
+# Already non-root: nothing to drop to, and no privilege to chown with. Both
+# paths ship owned by "node"; any other uid needs the host side sorted out.
 if [ "$(id -u)" != "0" ]; then
     mkdir -p /app/data /app/public/uploads 2>/dev/null || true
     exec "$@"
@@ -24,8 +14,6 @@ fi
 
 for dir in /app/data /app/public/uploads; do
     mkdir -p "$dir"
-    # Skip the chown when ownership is already correct, so an upgrade of a
-    # deployment whose volumes are fine does not walk the whole tree.
     owner="$(stat -c '%u:%g' "$dir")"
     if [ "$owner" != "$(id -u node):$(id -g node)" ]; then
         chown -R node:node "$dir" 2>/dev/null || true

--- a/lib/db/db-path.mjs
+++ b/lib/db/db-path.mjs
@@ -1,0 +1,11 @@
+import path from "node:path";
+
+// Shared by lib/db/index.ts and scripts/migrate.mjs. If these two ever resolve
+// differently, migrations run against one file and the server opens another,
+// silently and with no error.
+export function resolveDatabasePath() {
+  return (
+    process.env.DATABASE_URL?.replace("file:", "") ||
+    path.join(process.cwd(), "data", "sqlite.db")
+  );
+}

--- a/lib/db/index.ts
+++ b/lib/db/index.ts
@@ -1,19 +1,13 @@
 import { drizzle } from "drizzle-orm/better-sqlite3";
 import Database from "better-sqlite3";
 import * as schema from "./schema";
+import { resolveDatabasePath } from "./db-path.mjs";
 import path from "path";
 import fs from "fs";
 
-// Determine database path
-const dbPath =
-  process.env.DATABASE_URL?.replace("file:", "") ||
-  path.join(process.cwd(), "data", "sqlite.db");
+const dbPath = resolveDatabasePath();
 
-// Ensure the data directory exists
-const dataDir = path.dirname(dbPath);
-if (!fs.existsSync(dataDir)) {
-  fs.mkdirSync(dataDir, { recursive: true });
-}
+fs.mkdirSync(path.dirname(dbPath), { recursive: true });
 
 const sqlite = new Database(dbPath);
 export const db = drizzle(sqlite, { schema });

--- a/next.config.ts
+++ b/next.config.ts
@@ -7,6 +7,13 @@ const nextConfig: NextConfig = {
   /* config options here */
   output: "standalone",
 
+  // No <Image> anywhere: avatars are plain <img>. Declaring that lets the
+  // trace exclude below drop sharp (~46 MB) without breaking a reachable path.
+  images: { unoptimized: true },
+  outputFileTracingExcludes: {
+    "next-server": ["**/node_modules/sharp/**/*", "**/node_modules/@img/**/*"],
+  },
+
   // Build optimizations
   compiler: {
     removeConsole: process.env.NODE_ENV === "production"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "npm run lint && npm run build && npm run i18n",
     "test:ci": "npm run lint && npm run build && npm run i18n && npm run db:generate && npm run db:migrate",
     "db:generate": "drizzle-kit generate",
-    "db:migrate": "drizzle-kit migrate",
+    "db:migrate": "node scripts/migrate.mjs",
     "db:studio": "drizzle-kit studio",
     "db:push": "drizzle-kit push",
     "i18n": "tsx scripts/i18n-checks.ts",

--- a/scripts/migrate.mjs
+++ b/scripts/migrate.mjs
@@ -1,0 +1,34 @@
+/**
+ * Applies pending migrations. Runs as `npm run db:migrate` and as the
+ * container's CMD, so the same migrator covers dev, CI and production.
+ *
+ * Uses drizzle-orm's migrator rather than drizzle-kit, which is a build-time
+ * tool that would drag a full dev dependency tree into the runtime image.
+ * The two share bookkeeping -- same __drizzle_migrations table, same
+ * sha256-of-.sql hashes -- so an upgraded container replays nothing.
+ *
+ * Plain .mjs, not .ts like scripts/i18n-checks.ts: the runtime image ships no
+ * tsx, so this has to run under bare node.
+ */
+import fs from "node:fs";
+import path from "node:path";
+
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import { migrate } from "drizzle-orm/better-sqlite3/migrator";
+
+import { resolveDatabasePath } from "../lib/db/db-path.mjs";
+
+const dbPath = resolveDatabasePath();
+fs.mkdirSync(path.dirname(dbPath), { recursive: true });
+
+const sqlite = new Database(dbPath);
+
+try {
+  migrate(drizzle(sqlite), {
+    migrationsFolder: path.join(process.cwd(), "drizzle"),
+  });
+  console.log(`[Migrate] Schema is up to date: ${dbPath}`);
+} finally {
+  sqlite.close();
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,6 +25,7 @@
   "include": [
     "next-env.d.ts",
     "**/*.ts",
+    "**/*.mjs",
     "**/*.tsx",
     ".next/types/**/*.ts",
     ".next/dev/types/**/*.ts",


### PR DESCRIPTION
## Why

The production image was 1.01GB and slow to build and push. One layer accounted for 782MB of it: `COPY --from=prod-deps /app/node_modules`, a full `npm ci --omit=dev` tree whose only job was providing `drizzle-kit` so the container could run `npm run db:migrate` at startup. That pulled in `next` (199MB), `@next` (184MB), `@swc` (72MB) and `@img` (46MB) — all of which the standalone output already bundles.

## Result

| | Before | After |
| --- | --- | --- |
| Image | 1.01 GB | **203 MB** |
| Push payload (compressed) | 315 MB | **71 MB** |

| Change | Saving |
| --- | --- |
| `prod-deps` stage removed | 782 MB + ~256 s build time |
| sharp / `@img` excluded from the trace | 46 MB |
| `drizzle-orm` pruned of source maps and typings | 12 MB |

## How the migration swap is safe

`scripts/migrate.mjs` uses drizzle-orm's migrator instead of drizzle-kit. The two are bookkeeping-compatible: same `__drizzle_migrations` table, same sha256-of-`.sql` hash per migration, same `created_at`/`folderMillis` comparison.

Verified against a real drizzle-kit-migrated database: 15 migrations before, 15 after, no replay, data intact. A fresh install creates all 15 tables and reports healthy. Both were tested by running the built image, not by reading code.

`db:migrate` now points at the same script, so `pr-checks.yml` and `release.yml` exercise the production migration path on every PR — previously CI only ever ran the drizzle-kit variant while users got the other one.

## sharp

`outputFileTracingExcludes` needs the `"next-server"` key here, not a route glob — sharp is pulled in by the next-server trace, so a `"/*"` key has no effect. With the right key the standalone output drops from 80MB to 33MB, and transitive orphans (`detect-libc`, `@emnapi`, `semver`) go with it. Paired with `images.unoptimized`, which is a truthful declaration: the app renders no `<Image>`, avatars are plain `<img>`.

## ⚠️ Breaking change: ARM builds removed

Both workflows built `linux/arm64` under QEMU emulation on amd64 runners, where `npm ci` took 219s against 46s native — the whole Dockerfile ran a second time at roughly 4.7x. The `docker/setup-qemu-action` step is gone from both workflows.

**From `v3.0.0`, images are `linux/amd64` only.** ARM deployments must pin to `v2.2.1`. Documented in the README under Docker Images.

## Also in here

- **Changelog generator** now recognises the conventional `!` breaking marker and emits a Breaking Changes section. It also fixes a pre-existing bug: scoped types like `fix(auth):` did not match `^fix:` and silently fell into "Other Changes".
- **`.dockerignore`**: Docker matches patterns against the whole relative path, so the bare `node_modules` and `.next/` entries only ever excluded the repo root. Now `**/`-prefixed, plus `.claude` (agent worktrees, 1.8GB locally).
- **CI**: cache export only on `main` (Actions caches are ref-scoped, so a PR's `mode=max` export is never read back and evicts main's entry — ~5.5 min per PR run), `paths-ignore` for translation/docs-only PRs, `provenance: false` on the dev image.
- **Comments trimmed** throughout the Docker files. The entrypoint header documented a path (`./data/uploads`) the code does not touch.

## Verification

`npm run lint` (0 errors), `npm run i18n`, `npx tsc --noEmit`, `actionlint` (7 findings, unchanged from `main`, all pre-existing SC2086), plus container runs against both an existing and an empty database with all routes and static assets checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjF5TBeLfB952UygxgJ4ud

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a dedicated database migration runner that applies pending migrations automatically at startup.
  - Database file locations now support `DATABASE_URL` with a default SQLite path.

- **Changes**
  - Docker releases now target `linux/amd64` only. ARM images are no longer built after v2.2.1.
  - Docker builds are more streamlined and exclude unnecessary development files.
  - Pull requests containing only translations, documentation, or Markdown changes no longer trigger development image builds.
  - Next.js image optimization is disabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->