### PR TITLE
chore: hold eslint at 9 until eslint-plugin-react supports 10

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -28,6 +28,15 @@ updates:
       - dependency-name: "better-sqlite3"
         versions:
           - ">= 13.0.0"
+      # 10 removes the deprecated rule-context methods, which eslint-plugin-react
+      # still calls (`contextOrFilename.getFilename is not a function`). Its
+      # newest release, 7.37.5, caps its peer range at eslint ^9.7, and
+      # eslint-config-next pins ^7.37.0 even on canary — so there is no override
+      # that fixes this. eslint-config-next's own peer range of ">=9.0.0" is what
+      # lets npm install 10 in the first place. Revisit once that chain supports 10.
+      - dependency-name: "eslint"
+        versions:
+          - ">= 10.0.0"
 
   # GitHub Actions workflows (root)
   - package-ecosystem: "github-actions"


### PR DESCRIPTION
Blocks the ESLint 10 upgrade (#165), which fails CI before linting a single file.

## The failure

```
TypeError: Error while loading rule 'react/display-name': contextOrFilename.getFilename is not a function
    at resolveBasedir (node_modules/eslint-config-next/node_modules/eslint-plugin-react/lib/util/version.js:31:100)
```

ESLint 10 removed the deprecated rule-context methods (`context.getFilename()` and friends). `eslint-plugin-react` still calls them while detecting the React version, so the run aborts during rule loading — this is not a lint finding that could be fixed in our code.

## Why it cannot be worked around

| | |
|---|---|
| `eslint-plugin-react` latest | **7.37.5**, peer range `^3 \|\| … \|\| ^9.7` — no ESLint 10 support published |
| `eslint-config-next@16.3.4` | depends on `eslint-plugin-react@^7.37.0` |
| `eslint-config-next@16.4.0-canary.25` | still `^7.37.0` |

There is no newer plugin release to pin via `overrides`, and no newer `eslint-config-next` that has moved on. The upgrade has to wait for that chain.

Worth noting as the root cause of the noise: `eslint-config-next` declares its ESLint peer range as `>=9.0.0`, so npm installs 10 without any peer warning and Dependabot sees a clean upgrade. The ignore rule is what actually records the constraint.

## Verification

`npm run lint` (0 errors / 17 warnings, unchanged from `main`) and `npm run i18n` pass — the toolchain is untouched, this only adds a Dependabot rule alongside the existing `better-auth` and `better-sqlite3` entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SjF5TBeLfB952UygxgJ4ud