### PR TITLE
chore: fail PR checks when .nvmrc and the Dockerfile Node major diverge

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -21,6 +21,17 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
 
+      - name: Check .nvmrc matches the Dockerfile base image
+        shell: bash
+        run: |
+          # Dependabot bumps the Dockerfile but cannot touch .nvmrc, so fail loudly on drift.
+          nvmrc="$(sed 's/^v//; s/\..*//' .nvmrc | tr -d '[:space:]')"
+          mapfile -t majors < <(grep -oE '^FROM node:[0-9]+' Dockerfile | cut -d: -f2 | sort -u)
+          if [ "${#majors[@]}" -ne 1 ] || [ "${majors[0]}" != "$nvmrc" ]; then
+            echo "::error file=.nvmrc::.nvmrc pins Node $nvmrc, Dockerfile uses ${majors[*]:-none}"
+            exit 1
+          fi
+
       - name: Setup Node.js
         uses: actions/setup-node@v7
         with:


### PR DESCRIPTION
## Why

`.nvmrc` pins the Node version CI runs on (`node-version-file` in `pr-checks.yml` and `release.yml`), while the `Dockerfile` hardcodes `node:24-alpine` across its three stages. Nothing connects the two.

`.github/dependabot.yml` has a `docker` ecosystem entry specifically to pick up that base image. Dependabot can bump the `FROM` lines but has no way to touch `.nvmrc`, so a base-image update would leave CI building and type-checking on a different Node major than the image we actually ship — with no failing check anywhere.

## What

One step at the top of the `test` job, before `setup-node` and `npm ci`, asserting that `.nvmrc` and every `FROM node:` line agree on the major. It needs only the checkout and finishes in about a second, so it fails fast rather than after a full build.

The `${#majors[@]} -ne 1` guard is the part worth keeping: it catches a *partial* bump where only one of the three stages moves, which a comparison against the first match alone would wave through.

## Verification

Current tree is consistent (`.nvmrc` = 24, Dockerfile = `node:24-alpine` ×3). Ran the script against the real files and four mutated copies:

| Input | Result |
| --- | --- |
| Current tree | passes, Node 24 |
| Dockerfile fully bumped to 26 | fails — `uses 26` |
| Only one stage bumped to 26 | fails — `uses 24 26` |
| `.nvmrc` written as `v24.3.0` | passes, Node 24 |
| `.nvmrc` 22 vs. Dockerfile 24 | fails |

## Notes

- `package.json` `engines.node` is `>=22` — a floor, not a pin, so it is deliberately out of scope here.
- Not added to `release.yml`: a Dependabot Docker PR runs through these checks, so drift is caught before the merge; a release builds from a tag on `main` that already passed them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018eaZHndbK4nk3PYgwCbkj4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added an automated check to ensure the Node.js versions configured for development and container builds remain consistent.
  * Pull requests now fail validation when the versions differ or the container configuration is missing a single valid Node.js base version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->