### PR TITLE
feat(stats): show days off in the detailed shift statistics

### DIFF
--- a/components/shift-stats.tsx
+++ b/components/shift-stats.tsx
@@ -10,6 +10,8 @@ import { usePresets } from "@/hooks/usePresets";
 import { SegmentedControl } from "@/components/segmented-control";
 import { ChoiceChips } from "@/components/form-kit";
 import { formatHours } from "@/lib/shift-display";
+import { countFreeDays } from "@/lib/free-days";
+import { cn } from "@/lib/utils";
 import {
   PieChart as RechartsPieChart,
   Pie,
@@ -168,6 +170,7 @@ export function ShiftStats({ calendarId, currentDate }: ShiftStatsProps) {
   const totalShifts = stats?.totalShifts || 0;
   const totalMinutes = stats?.totalMinutes || 0;
   const hasData = !!stats && Object.keys(stats.stats).length > 0;
+  const freeDays = stats ? countFreeDays(stats) : null;
 
   // Prepare data for charts
   const pieData = stats
@@ -240,13 +243,20 @@ export function ShiftStats({ calendarId, currentDate }: ShiftStatsProps) {
         <>
           {viewMode === "overview" && (
             <>
-              <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+              {/* Without timed shifts only four tiles remain, so keep them on one row */}
+              <div
+                className={cn(
+                  "grid grid-cols-2 gap-2",
+                  stats.maxDuration > 0 ? "sm:grid-cols-3" : "sm:grid-cols-4"
+                )}
+              >
                 <KpiTile label={t("stats.totalShifts")} value={totalShifts} />
                 <KpiTile label={t("stats.totalHours")} value={formatHours(totalMinutes, locale)} />
                 <KpiTile
                   label={t("stats.avgPerShift")}
                   value={formatHours(stats.avgMinutesPerShift, locale)}
                 />
+                <KpiTile label={t("calendarView.kpiFreeDays")} value={freeDays ?? "–"} />
                 {stats.minDuration > 0 && (
                   <KpiTile
                     label={t("stats.shortestShift")}

--- a/hooks/useDaySummary.ts
+++ b/hooks/useDaySummary.ts
@@ -1,8 +1,8 @@
 "use client";
 
 import { useMemo } from "react";
-import { getDaysInMonth, getDaysInYear } from "date-fns";
 import { ShiftWithCalendar } from "@/lib/types";
+import { countFreeDays } from "@/lib/free-days";
 import { CalendarNote } from "@/lib/db/schema";
 import { findNotesForDate } from "@/lib/event-utils";
 import { getShiftMinutes, getShiftsForDay, sortShifts } from "@/lib/shift-display";
@@ -78,15 +78,8 @@ export function usePeriodSummary({
           .sort((a, b) => b.count - a.count)
       : [];
 
-    let freeDays: number | null = null;
-    if (stats && period === "month") {
-      freeDays = getDaysInMonth(anchorDate) - stats.daysWithShifts;
-    } else if (stats && period === "week") {
-      freeDays = 7 - stats.daysWithShifts;
-    } else if (stats) {
-      freeDays = getDaysInYear(anchorDate) - stats.daysWithShifts;
-    }
+    const freeDays = stats ? countFreeDays(stats) : null;
 
     return { stats, freeDays, byType, loading };
-  }, [stats, loading, shifts, anchorDate, period]);
+  }, [stats, loading, shifts]);
 }

--- a/lib/free-days.ts
+++ b/lib/free-days.ts
@@ -1,0 +1,20 @@
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+interface StatsWindow {
+  startDate: string;
+  endDate: string;
+  daysWithShifts: number;
+}
+
+/**
+ * Days in the stats API's window without a stats-counted shift. `startDate`/`endDate` are
+ * ISO instants of the server-local period bounds, so only their distance is used, never a calendar date.
+ */
+export function countFreeDays({ startDate, endDate, daysWithShifts }: StatsWindow): number | null {
+  const start = Date.parse(startDate);
+  const end = Date.parse(endDate);
+  if (Number.isNaN(start) || Number.isNaN(end) || end < start) return null;
+  // The end is inclusive (23:59:59.999); rounding also absorbs 23h/25h DST days.
+  const periodDays = Math.round((end - start) / DAY_MS);
+  return Math.max(0, periodDays - daysWithShifts);
+}


### PR DESCRIPTION
## What

The detailed statistics dialog (`ShiftStats`) gets a **Freie Tage** KPI tile for week, month and year, reusing `calendarView.kpiFreeDays`. Tile order now matches the compact period summary: Schichten gesamt, Stunden gesamt, ⌀ pro Schicht, Freie Tage, then Kürzeste/Längste.

- New pure helper `lib/free-days.ts` → `countFreeDays({ startDate, endDate, daysWithShifts })`, used by both `usePeriodSummary` (compact view) and `ShiftStats`, so the two views can no longer drift apart.
- Grid layout: Kürzeste/Längste only exist when there are timed shifts, so there are either 6 or 4 tiles. With 6 tiles it stays `sm:grid-cols-3` (two full rows, filling the empty sixth cell). With 4 tiles (e.g. only all-day Urlaub) it switches to `sm:grid-cols-4`, so no single orphan tile ends up on a second row. Phone stays 2 columns either way.
- The semantics are the same as the compact view: days in the period minus the API's `daysWithShifts`. All-day shifts count as "not free", and hidden or hide-from-stats shifts are excluded, because the API already filters them.
- The other tabs (Verteilung, Vergleich, Radar) only show per-shift-type data and have no per-period KPI tiles, so free days don't belong there and they are unchanged.
- The API is unchanged.

## How the period length is derived, and why

`/api/shifts/stats` returns `startDate`/`endDate` as full ISO instants built with date-fns in the **server's** time zone (`startOfMonth(...).toISOString()`, `endOfMonth(...)` = 23:59:59.999). Slicing those to `YYYY-MM-DD` or reading them as calendar dates on the client would be wrong whenever the server is not in UTC. Berlin's March, for example, starts at `2026-02-28T23:00:00.000Z`.

So the helper uses only the **distance** between the two instants: `Math.round((end - start) / 1 day)`. Rounding absorbs the inclusive end (−1 ms) and 23h/25h DST days. No calendar date is ever reconstructed, so no UTC conversion is involved and `parseLocalDate`/`formatDateToLocal` aren't needed.

I chose this over the previous "period + client anchor date" approach (`getDaysInMonth(anchorDate)`) because the day count then always describes the exact window the server counted `daysWithShifts` over. The route parses the `date` param with `new Date("YYYY-MM-DD")`, i.e. UTC midnight, so on a server behind UTC an anchor on the 1st lands in the previous month. The anchor-based count then mixed two different months; now free days at least agree with every other number on screen. That route behaviour is pre-existing and out of scope here. The result is clamped at 0, and unparsable dates yield `null` (tile shows "–").

## Verification

- `npx tsc --noEmit`, `npm run lint` (only the pre-existing warning in `app/page.tsx`), `npm run i18n` (100 %, 0 unused)
- A throwaway `tsx` script (not committed) rebuilt the route's window with date-fns and checked 28/29/30/31-day months, DST months, leap (2028) and non-leap (2026, 2100) years, a normal week, weeks across DST and year boundaries, zero shifts, clamping and invalid input. All passed under `TZ` = UTC, Europe/Berlin, America/New_York, Asia/Kolkata, Australia/Lord_Howe, Pacific/Kiritimati and America/St_Johns.
- No build, dev server or browser run in this unit; visual check is pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSpX5Vc9i4MHxAS3eFHS2X
