### PR TITLE
fix(ui): show the chosen highlight colour in dark mode and drop redundant admin header controls

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useLocale, useTranslations } from "next-intl";
 import { format, formatDistanceToNow } from "date-fns";
-import { ArrowUpCircle, ChevronRight, FolderClosed, RefreshCw } from "lucide-react";
+import { ArrowUpCircle, ChevronRight, FolderClosed } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Pill } from "@/components/form-kit";
 import { StatusBanner } from "@/components/status-banner";
@@ -56,8 +56,8 @@ export default function AdminDashboardPage() {
   const describe = useAuditDescription();
   const host = useSyncExternalStore(noSubscribe, () => window.location.host, () => "");
 
-  const { stats, refetch: refetchStats } = useAdminStats();
-  const { versionInfo, refetch: refetchVersion } = useVersionUpdateCheck();
+  const { stats } = useAdminStats();
+  const { versionInfo } = useVersionUpdateCheck();
   const adminLogs = useAdminAuditLogs(ADMIN_FILTER, ACTIVITY_SORT, ACTIVITY_PAGE);
   const securityLogs = useAdminAuditLogs(SECURITY_FILTER, ACTIVITY_SORT, ACTIVITY_PAGE);
   const logsCount = useAdminAuditLogs(undefined, undefined, COUNT_PAGINATION);
@@ -83,13 +83,6 @@ export default function AdminDashboardPage() {
       ? format(new Date(versionInfo.buildDate), "PPp", { locale: dateLocale })
       : t("admin.systemInfo.unknown");
 
-  const reload = () => {
-    refetchStats();
-    refetchVersion();
-    adminLogs.refetch();
-    securityLogs.refetch();
-  };
-
   const versionPill = versionInfo?.isDev ? (
     <Pill tone="warning" className="text-[11px]">{t("admin.systemInfo.development")}</Pill>
   ) : hasUpdate ? (
@@ -107,13 +100,6 @@ export default function AdminDashboardPage() {
     >
       {t("admin.systemInfo.viewOnGitHub")}
     </a>
-  );
-
-  const reloadButton = (
-    <Button variant="outline" onClick={reload} className="h-9 gap-2 rounded-[9px] px-[13px] text-[13.5px] font-semibold">
-      <RefreshCw className="size-[15px] text-fg-secondary" />
-      {t("adminDashboard.reload")}
-    </Button>
   );
 
   const scaleRows = [
@@ -177,24 +163,21 @@ export default function AdminDashboardPage() {
           </>
         }
         actions={
-          <div className="flex flex-wrap items-center justify-end gap-4">
-            {versionInfo && (
-              <>
-                <SystemItem label={t("admin.systemInfo.version")}>
-                  <span className="font-mono text-[14px] font-semibold text-fg-strong">{versionInfo.version}</span>
-                  {versionPill}
-                </SystemItem>
-                <SystemItem label={t("admin.systemInfo.buildDate")}>
-                  <span className="text-[14px] font-semibold text-fg-strong">{buildDate}</span>
-                </SystemItem>
-                <SystemItem label={t("admin.systemInfo.commitHash")}>
-                  <span className="font-mono text-[14px] font-semibold text-fg-strong">{versionInfo.commitHash}</span>
-                  {githubLink}
-                </SystemItem>
-              </>
-            )}
-            {reloadButton}
-          </div>
+          versionInfo && (
+            <div className="flex flex-wrap items-center justify-end gap-x-5 gap-y-2">
+              <SystemItem label={t("admin.systemInfo.version")}>
+                <span className="font-mono text-[14px] font-semibold text-fg-strong">{versionInfo.version}</span>
+                {versionPill}
+              </SystemItem>
+              <SystemItem label={t("admin.systemInfo.buildDate")}>
+                <span className="text-[14px] font-semibold text-fg-strong">{buildDate}</span>
+              </SystemItem>
+              <SystemItem label={t("admin.systemInfo.commitHash")}>
+                <span className="font-mono text-[14px] font-semibold text-fg-strong">{versionInfo.commitHash}</span>
+                {githubLink}
+              </SystemItem>
+            </div>
+          )
         }
         mobileActions={<UserMenu />}
       />
@@ -351,7 +334,6 @@ export default function AdminDashboardPage() {
                 </span>
                 {githubLink}
               </SystemItem>
-              <div className="pt-1">{reloadButton}</div>
             </div>
           </section>
         </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -178,6 +178,9 @@
   /* Shift chips: arbitrary DB colors, tinted per theme */
   --shift-tint: 8%;
   --shift-ink-mix: #101828 22%;
+
+  /* Highlighted weekdays: share of the user's colour over the cell surface */
+  --highlight-tint: 10%;
 }
 
 .dark {
@@ -258,6 +261,7 @@
   --sidebar-ring: #3b82f6;
 
   --shift-tint: 16%;
+  --highlight-tint: 22%;
 }
 
 @layer base {
@@ -341,5 +345,14 @@
   }
   .dark .shift-text {
     color: color-mix(in oklch, var(--shift-base) 55%, white);
+  }
+
+  /*
+   * Weekday highlight. Set --highlight to the chosen hex. A flat layer over the cell's own
+   * background keeps weekend and hover; srgb, because oklch drags the hue toward the navy dark cell.
+   */
+  .day-highlight {
+    --highlight-layer: color-mix(in srgb, var(--highlight) var(--highlight-tint), transparent);
+    background-image: linear-gradient(var(--highlight-layer), var(--highlight-layer));
   }
 }

--- a/components/admin/admin-header.tsx
+++ b/components/admin/admin-header.tsx
@@ -2,90 +2,12 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useLocale, useTranslations } from "next-intl";
-import { useTheme } from "next-themes";
-import { ChevronRight, Languages, SunMoon } from "lucide-react";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuLabel,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuTrigger,
-} from "@/components/ui/dropdown-menu";
+import { useTranslations } from "next-intl";
+import { ChevronRight } from "lucide-react";
 import { UserMenu } from "@/components/user-menu";
-import { useThemeOptions } from "@/components/appearance-picker";
-import { setLocaleCookie } from "@/components/app-preferences-menu-items";
 import { isActiveSection, useAdminSections } from "@/components/admin/admin-sidebar";
-import { locales } from "@/lib/locales";
 
-function LanguageSelect() {
-  const t = useTranslations();
-  const locale = useLocale();
-  const names: Record<string, string> = {
-    de: t("language.de"),
-    en: t("language.en"),
-    es: t("language.es"),
-    fr: t("language.fr"),
-    it: t("language.it"),
-    cs: t("language.cs"),
-  };
-
-  return (
-    <Select value={locale} onValueChange={setLocaleCookie}>
-      <SelectTrigger
-        size="sm"
-        aria-label={t("appMenu.language")}
-        className="h-8 gap-[7px] rounded-lg border-line px-[11px] text-[13px] text-fg-body shadow-none"
-      >
-        <Languages className="size-[15px] text-fg-secondary" />
-        <SelectValue />
-      </SelectTrigger>
-      <SelectContent align="end">
-        {locales.map((value) => (
-          <SelectItem key={value} value={value}>
-            {names[value] ?? value}
-          </SelectItem>
-        ))}
-      </SelectContent>
-    </Select>
-  );
-}
-
-function AppearanceMenu() {
-  const t = useTranslations();
-  const { theme, setTheme } = useTheme();
-  const options = useThemeOptions();
-
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <button
-          type="button"
-          aria-label={t("appearance.title")}
-          className="flex size-8 items-center justify-center rounded-lg border border-line text-fg-secondary transition-colors hover:bg-surface-panel"
-        >
-          <SunMoon className="size-4" />
-        </button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end" className="w-48">
-        <DropdownMenuLabel className="text-[12px] font-semibold text-fg-tertiary">
-          {t("appearance.title")}
-        </DropdownMenuLabel>
-        <DropdownMenuRadioGroup value={theme ?? "system"} onValueChange={setTheme}>
-          {options.map(({ value, title }) => (
-            <DropdownMenuRadioItem key={value} value={value}>
-              {title}
-            </DropdownMenuRadioItem>
-          ))}
-        </DropdownMenuRadioGroup>
-      </DropdownMenuContent>
-    </DropdownMenu>
-  );
-}
-
-/** Desktop top bar: breadcrumb, language, appearance and account menu. */
+/** Desktop top bar: breadcrumb and account menu (which also holds appearance and language). */
 export function AdminHeader() {
   const t = useTranslations();
   const pathname = usePathname();
@@ -107,8 +29,6 @@ export function AdminHeader() {
           </>
         )}
       </nav>
-      <LanguageSelect />
-      <AppearanceMenu />
       <UserMenu />
     </header>
   );

--- a/components/month-grid.tsx
+++ b/components/month-grid.tsx
@@ -128,7 +128,8 @@ export function MonthGrid({
           const today = isToday(day);
           const selected = isSameLocalDay(day, selectedDay);
           const weekend = day.getDay() === 0 || day.getDay() === 6;
-          const highlighted = highlightedWeekdays.includes(day.getDay());
+          const highlighted =
+            !!highlightColor && !today && highlightedWeekdays.includes(day.getDay());
           const toggling = togglingDates.has(key);
 
           const dayNotes = inMonth ? findNotesForDate(notes, day) : [];
@@ -173,11 +174,7 @@ export function MonthGrid({
               onTouchEnd={cancelPress}
               onTouchMove={cancelPress}
               style={
-                highlighted && highlightColor && !today
-                  ? {
-                      backgroundColor: `color-mix(in oklch, ${highlightColor} 9%, var(--surface-cell))`,
-                    }
-                  : undefined
+                highlighted ? ({ "--highlight": highlightColor } as React.CSSProperties) : undefined
               }
               className={cn(
                 "relative flex min-h-0 min-w-0 select-none flex-col overflow-hidden text-left outline-none transition-colors [-webkit-touch-callout:none]",
@@ -190,6 +187,7 @@ export function MonthGrid({
                     ? "bg-surface-weekend"
                     : "bg-surface-cell",
                 !today && "hover:bg-surface-panel",
+                highlighted && "day-highlight",
                 !inMonth && "opacity-45",
                 selected && "shadow-[inset_0_0_0_1.5px_var(--brand-dot)]",
                 toggling && "cursor-wait opacity-60",

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -951,7 +951,6 @@
   },
   "adminDashboard": {
     "title": "Přehled",
-    "reload": "Znovu načíst",
     "attention": "{count, plural, one {Jedna věc vyžaduje pozornost} few {# věci vyžadují pozornost} other {# věcí vyžaduje pozornost}}",
     "allClear": "Nic teď nevyžaduje pozornost",
     "openCalendars": "Otevřít kalendáře",

--- a/messages/de.json
+++ b/messages/de.json
@@ -951,7 +951,6 @@
   },
   "adminDashboard": {
     "title": "Übersicht",
-    "reload": "Neu laden",
     "attention": "{count, plural, one {Eine Sache braucht Aufmerksamkeit} other {# Dinge brauchen Aufmerksamkeit}}",
     "allClear": "Nichts braucht gerade Aufmerksamkeit",
     "openCalendars": "Kalender öffnen",

--- a/messages/en.json
+++ b/messages/en.json
@@ -951,7 +951,6 @@
   },
   "adminDashboard": {
     "title": "Overview",
-    "reload": "Reload",
     "attention": "{count, plural, one {One thing needs attention} other {# things need attention}}",
     "allClear": "Nothing needs attention right now",
     "openCalendars": "Open calendars",

--- a/messages/es.json
+++ b/messages/es.json
@@ -951,7 +951,6 @@
   },
   "adminDashboard": {
     "title": "Resumen",
-    "reload": "Recargar",
     "attention": "{count, plural, one {Una cosa requiere atención} other {# cosas requieren atención}}",
     "allClear": "Nada requiere atención ahora",
     "openCalendars": "Abrir calendarios",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -951,7 +951,6 @@
   },
   "adminDashboard": {
     "title": "Aperçu",
-    "reload": "Recharger",
     "attention": "{count, plural, one {Un point à traiter} other {# points à traiter}}",
     "allClear": "Rien à traiter pour le moment",
     "openCalendars": "Ouvrir les calendriers",

--- a/messages/it.json
+++ b/messages/it.json
@@ -951,7 +951,6 @@
   },
   "adminDashboard": {
     "title": "Panoramica",
-    "reload": "Ricarica",
     "attention": "{count, plural, one {Una cosa richiede attenzione} other {# cose richiedono attenzione}}",
     "allClear": "Al momento nulla richiede attenzione",
     "openCalendars": "Apri calendari",


### PR DESCRIPTION
Addresses three review notes on the redesign stack (#172–#176).

## Weekday highlight colour in dark mode

**Root cause.** `MonthGrid` set an inline `backgroundColor: color-mix(in oklch, <colour> 9%, var(--surface-cell))`. oklch interpolates hue along the arc between both colours. In dark mode `--surface-cell` is `#121926`, a navy with real chroma (oklch h≈262). At 9% the mix therefore landed near h≈270 for every pick, which reads as blue or indigo whether the user chose red or violet. Light mode looked right only because white has no hue. The inline style also overrode the hover and weekend surfaces.

**Fix.**
- The cell now sets only `--highlight` inline.
- The new `.day-highlight` class (in `app/globals.css`) lays a flat sRGB tint of that colour over the cell's own background. The tint is `color-mix(in srgb, var(--highlight) var(--highlight-tint), transparent)` as a background-image layer. That is equivalent to `color-mix(in srgb, highlight, base)`, but the base colour stays whatever the cell's classes say.
- Because the base is untouched, weekend shading and the hover step still work. Today stays un-highlighted, and the selected and focus rings are unaffected.
- New token `--highlight-tint`: **10%** in `:root`, **22%** in `.dark`, next to `--shift-tint`.
- Shift chips are translucent or solid layers on top and keep their existing contrast.
- Both call sites (calendar workspace and compare mode) pass the colour through unchanged.

Computed dark-cell results at 22% (sRGB, over `#121926`):

| Preset | Result | oklch hue |
|---|---|---|
| Red `#dc2626` | `#3e1c26` | 3° (wine red) |
| Violet `#7c3aed` | `#292052` | 288° |
| Green `#059669` | `#0f3535` | 196° |
| Amber `#d97706` | `#3e2e1f` | 64° |
| Pink `#db2777` | `#3e1c38` | 335° |
| Blue `#2563eb` | `#162951` | 263° |

In light mode at 10% over white: red `#fce9e9`, violet `#f2ebfd`.

## Admin clean-up

- Removed the "Neu laden" button from the dashboard's desktop header and from the phone system-info card, along with the `adminDashboard.reload` key in all six locales. Stats and audit logs already poll.
- The header actions now render only when version info is loaded. Version, build and commit sit bottom-aligned with the subtitle.
- Removed the language select and theme menu from the admin top bar. `UserMenu`, which already offers both, stays. No i18n keys became unused: they are all still used by the user menu and the settings dialog.

## Checks

- `npx tsc --noEmit` passes.
- `npm run lint`: 0 errors. The one warning in `app/page.tsx` was already there.
- `npm run i18n`: 100%, 0 unused keys.

Not verified in a browser yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSpX5Vc9i4MHxAS3eFHS2X
