### PR TITLE
feat(ui): collapse secondary presets behind "More" and rename stamps to presets

### DIFF
--- a/components/compare-workspace.tsx
+++ b/components/compare-workspace.tsx
@@ -19,7 +19,7 @@ import { Button } from "@/components/ui/button";
 import { MonthGrid } from "@/components/month-grid";
 import { MonthStepper } from "@/components/app-header";
 import { PresetManageSheet } from "@/components/preset-manage-sheet";
-import { orderStampPresets } from "@/components/stamp-dock";
+import { MorePresets, orderStampPresets, splitStampPresets } from "@/components/stamp-dock";
 import { MAX_COMPARE_CALENDARS } from "@/components/calendar-compare-sheet";
 import { useDayLabels } from "@/components/day-inspector";
 import { CalendarWithCount, ShiftWithCalendar } from "@/lib/types";
@@ -312,7 +312,7 @@ function CompareColumn({
   const t = useTranslations();
   const locale = useLocale();
   const { canEdit } = useCalendarPermission(calendar.id);
-  const presets = orderStampPresets(presetsMap.get(calendar.id) ?? []);
+  const { primary, secondary } = splitStampPresets(presetsMap.get(calendar.id) ?? []);
   const totals = monthTotals(shifts, currentDate);
 
   return (
@@ -333,31 +333,39 @@ function CompareColumn({
         </div>
         {canEdit && (
           <div className="mt-2.5 flex h-8 items-center gap-1.5 overflow-hidden">
-            {presets.map((preset, index) => {
-              const active = preset.id === selectedPresetId;
-              return (
-                <button
-                  key={preset.id}
-                  type="button"
-                  aria-pressed={active}
-                  onClick={() => onSelectPreset(active ? undefined : preset.id)}
-                  className={cn(
-                    "flex h-7 shrink-0 items-center gap-[7px] rounded-[7px] border px-2.5 text-[12.5px] font-medium transition-colors",
-                    active
-                      ? "border-brand bg-brand-soft text-brand-ink"
-                      : "border-line bg-surface-card text-fg-body hover:bg-surface-panel"
-                  )}
-                >
-                  <span className="size-[7px] rounded-full" style={{ backgroundColor: preset.color }} />
-                  {preset.title}
-                  {keysActive && index < 9 && (
-                    <kbd className="rounded-[4px] bg-surface-sunken px-1 font-mono text-[10px] font-normal text-fg-tertiary">
-                      {index + 1}
-                    </kbd>
-                  )}
-                </button>
-              );
-            })}
+            <div className="flex min-w-0 items-center gap-1.5 overflow-hidden empty:hidden">
+              {primary.map((preset, index) => {
+                const active = preset.id === selectedPresetId;
+                return (
+                  <button
+                    key={preset.id}
+                    type="button"
+                    aria-pressed={active}
+                    onClick={() => onSelectPreset(active ? undefined : preset.id)}
+                    className={cn(
+                      "flex h-7 shrink-0 items-center gap-[7px] rounded-[7px] border px-2.5 text-[12.5px] font-medium transition-colors",
+                      active
+                        ? "border-brand bg-brand-soft text-brand-ink"
+                        : "border-line bg-surface-card text-fg-body hover:bg-surface-panel"
+                    )}
+                  >
+                    <span className="size-[7px] rounded-full" style={{ backgroundColor: preset.color }} />
+                    {preset.title}
+                    {keysActive && index < 9 && (
+                      <kbd className="rounded-[4px] bg-surface-sunken px-1 font-mono text-[10px] font-normal text-fg-tertiary">
+                        {index + 1}
+                      </kbd>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+            <MorePresets
+              variant="compare"
+              presets={secondary}
+              selectedPresetId={selectedPresetId}
+              onSelectPreset={onSelectPreset}
+            />
             <button
               type="button"
               onClick={onManagePresets}
@@ -366,8 +374,8 @@ function CompareColumn({
             >
               <SlidersHorizontal className="size-3.5" />
             </button>
-            {!keysActive && presets.length > 0 && (
-              <span className="min-w-0 truncate pl-1 text-[12px] text-fg-tertiary">
+            {!keysActive && primary.length + secondary.length > 0 && (
+              <span className="min-w-0 flex-1 truncate pl-1 text-[12px] text-fg-tertiary">
                 {t("calendarCompare.tapToMoveStamp")}
               </span>
             )}
@@ -418,7 +426,8 @@ function CompareMobile({
   const legend = useMemo(() => {
     const seen = new Map<string, string>();
     for (const calendar of calendars) {
-      for (const preset of orderStampPresets(presetsMap.get(calendar.id) ?? [])) {
+      const { primary, secondary } = splitStampPresets(presetsMap.get(calendar.id) ?? []);
+      for (const preset of [...primary, ...secondary]) {
         if (!seen.has(preset.title)) seen.set(preset.title, preset.color);
       }
     }

--- a/components/preset-form.tsx
+++ b/components/preset-form.tsx
@@ -179,6 +179,7 @@ export function PresetFormCard({
           checked={value.isSecondary}
           onCheckedChange={(isSecondary) => onChange({ isSecondary })}
           disabled={disabled}
+          hint={t("presetSheet.markAsSecondaryHint")}
         >
           {t("presetSheet.markAsSecondary")}
         </CheckRow>

--- a/components/preset-list.tsx
+++ b/components/preset-list.tsx
@@ -99,7 +99,7 @@ function SortablePresetRow({
                 ? t("presetSheet.allDayShort")
                 : `${preset.startTime.slice(0, 5)} – ${preset.endTime.slice(0, 5)}`}
             </span>
-            {preset.isSecondary && <Pill tone="warning">{t("preset.secondary")}</Pill>}
+            {preset.isSecondary && <Pill>{t("preset.secondary")}</Pill>}
             {preset.hideFromStats && (
               <Pill tone="warning">{t("presetSheet.notInStats")}</Pill>
             )}

--- a/components/preset-manage-sheet.tsx
+++ b/components/preset-manage-sheet.tsx
@@ -177,7 +177,7 @@ export function PresetsPanel({
         )}
         {secondary.length > 0 && (
           <PresetSection
-            label={t("preset.secondary")}
+            label={t("presetSheet.secondarySection")}
             presets={secondary}
             onReorder={(next) => saveOrder([...primary, ...next])}
             {...rowActions}

--- a/components/stamp-dock.tsx
+++ b/components/stamp-dock.tsx
@@ -1,14 +1,236 @@
 "use client";
 
+import { ComponentProps, useState } from "react";
 import { useTranslations } from "next-intl";
-import { Plus, SlidersHorizontal, Hand } from "lucide-react";
+import {
+  Check,
+  ChevronDown,
+  ChevronUp,
+  Ellipsis,
+  Hand,
+  Plus,
+  SlidersHorizontal,
+} from "lucide-react";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { ShiftPreset } from "@/lib/db/schema";
 import { getShiftCode } from "@/lib/shift-display";
 import { cn } from "@/lib/utils";
 
-/** Primary presets first; the dock numbers them 1–9 in this order. */
+export function splitStampPresets(presets: ShiftPreset[]) {
+  return {
+    primary: presets.filter((p) => !p.isSecondary),
+    secondary: presets.filter((p) => p.isSecondary),
+  };
+}
+
+/** Presets that get their own chip and number key 1–9; secondary ones sit under "Weitere". */
 export function orderStampPresets(presets: ShiftPreset[]): ShiftPreset[] {
-  return [...presets.filter((p) => !p.isSecondary), ...presets.filter((p) => p.isSecondary)];
+  return splitStampPresets(presets).primary;
+}
+
+function presetTime(preset: ShiftPreset, allDayLabel: string) {
+  return preset.isAllDay
+    ? allDayLabel
+    : `${preset.startTime.slice(0, 5)} – ${preset.endTime.slice(0, 5)}`;
+}
+
+type MoreVariant = "dock" | "compare" | "bar";
+
+interface MoreChipProps extends ComponentProps<"button"> {
+  variant: MoreVariant;
+  count: number;
+  /** The armed secondary preset; the chip shows it in place so the row keeps its layout. */
+  active: ShiftPreset | undefined;
+  open: boolean;
+}
+
+function MoreChip({ variant, count, active, open, className, ...props }: MoreChipProps) {
+  const t = useTranslations();
+  const label = (
+    <span className="whitespace-nowrap">
+      {t("preset.secondary")}
+      <span className="opacity-60"> · </span>
+      <span className="font-mono">{count}</span>
+    </span>
+  );
+
+  if (variant === "bar") {
+    const Chevron = open ? ChevronDown : ChevronUp;
+    return (
+      <button
+        type="button"
+        aria-expanded={open}
+        {...props}
+        className={cn(
+          "flex h-12 shrink-0 items-center gap-2.5 rounded-[10px] border py-1.5 pl-2 pr-2.5 text-left transition-colors",
+          active
+            ? "border-brand bg-brand-soft"
+            : open
+              ? "border-control bg-surface-sunken"
+              : "border-line bg-surface-card",
+          className
+        )}
+      >
+        {active ? (
+          <>
+            <span
+              className="shift-solid flex size-[22px] shrink-0 items-center justify-center rounded-[5px] text-[11px] font-bold"
+              style={{ "--shift": active.color } as React.CSSProperties}
+            >
+              {getShiftCode(active.title)}
+            </span>
+            <span className="min-w-0">
+              <span className="block max-w-[140px] truncate text-[13px] font-semibold text-brand-ink">
+                {active.title}
+              </span>
+              <span className="block font-mono text-[11.5px] text-brand-ink">
+                {presetTime(active, t("shift.allDayShift"))}
+              </span>
+            </span>
+          </>
+        ) : (
+          <>
+            <span className="flex size-[22px] shrink-0 items-center justify-center rounded-[5px] bg-surface-sunken text-fg-secondary">
+              <Ellipsis className="size-3.5" />
+            </span>
+            <span className="text-[13px] font-semibold text-fg-strong">{label}</span>
+          </>
+        )}
+        <Chevron className={cn("size-4 shrink-0", active ? "text-brand-ink" : "text-fg-tertiary")} />
+      </button>
+    );
+  }
+
+  const dock = variant === "dock";
+  const Chevron = dock ? ChevronUp : ChevronDown;
+  const tone = dock
+    ? active
+      ? "bg-brand text-white"
+      : cn("text-[#e4e7ec] hover:bg-white/10", open && "bg-white/10")
+    : active
+      ? "border-brand bg-brand-soft text-brand-ink"
+      : cn(
+          "border-line bg-surface-card text-fg-body hover:bg-surface-panel",
+          open && "bg-surface-panel"
+        );
+  return (
+    <button
+      type="button"
+      {...props}
+      className={cn(
+        "flex shrink-0 items-center gap-[7px] px-2.5 text-[12.5px] font-medium transition-colors",
+        dock ? "h-[30px] rounded-lg" : "h-7 rounded-[7px] border",
+        tone,
+        className
+      )}
+    >
+      {active ? (
+        <>
+          <span className="size-[7px] shrink-0 rounded-full" style={{ backgroundColor: active.color }} />
+          <span className="max-w-[140px] truncate">{active.title}</span>
+        </>
+      ) : (
+        label
+      )}
+      <Chevron className="-mr-0.5 size-3.5 shrink-0 opacity-70" />
+    </button>
+  );
+}
+
+/** Secondary presets as rows; picking the armed one disarms it. */
+function SecondaryPresetList({
+  presets,
+  selectedPresetId,
+  onPick,
+  touch = false,
+}: {
+  presets: ShiftPreset[];
+  selectedPresetId: string | undefined;
+  onPick: (id: string | undefined) => void;
+  touch?: boolean;
+}) {
+  const t = useTranslations();
+  return (
+    <div className="flex flex-col gap-px">
+      {presets.map((preset) => {
+        const active = preset.id === selectedPresetId;
+        return (
+          <button
+            key={preset.id}
+            type="button"
+            aria-pressed={active}
+            onClick={() => onPick(active ? undefined : preset.id)}
+            className={cn(
+              "flex items-center gap-2.5 rounded-[8px] px-2.5 text-left outline-none transition-colors",
+              touch ? "h-11 text-[14px]" : "h-9 text-[13px]",
+              active
+                ? "bg-brand-soft text-brand-ink"
+                : "text-fg-body hover:bg-surface-sunken focus-visible:bg-surface-sunken"
+            )}
+          >
+            <span className="size-2 shrink-0 rounded-full" style={{ backgroundColor: preset.color }} />
+            <span className="min-w-0 flex-1 truncate font-medium">{preset.title}</span>
+            <span
+              className={cn(
+                "shrink-0 font-mono text-[12px]",
+                active ? "text-brand-ink" : "text-fg-tertiary"
+              )}
+            >
+              {presetTime(preset, t("presetSheet.allDayShort"))}
+            </span>
+            <Check className={cn("size-3.5 shrink-0", !active && "invisible")} />
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+interface MorePresetsProps {
+  /** Secondary presets only. */
+  presets: ShiftPreset[];
+  selectedPresetId: string | undefined;
+  onSelectPreset: (id: string | undefined) => void;
+}
+
+/** Trailing "Weitere · N" chip that opens the secondary presets in a popover. */
+export function MorePresets({
+  variant,
+  presets,
+  selectedPresetId,
+  onSelectPreset,
+}: MorePresetsProps & { variant: "dock" | "compare" }) {
+  const [open, setOpen] = useState(false);
+  if (presets.length === 0) return null;
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <MoreChip
+          variant={variant}
+          count={presets.length}
+          active={presets.find((p) => p.id === selectedPresetId)}
+          open={open}
+        />
+      </PopoverTrigger>
+      <PopoverContent
+        side={variant === "dock" ? "top" : "bottom"}
+        align={variant === "dock" ? "end" : "start"}
+        sideOffset={8}
+        collisionPadding={12}
+        className="w-[260px] rounded-[12px] border-line bg-surface-card p-1"
+      >
+        <SecondaryPresetList
+          presets={presets}
+          selectedPresetId={selectedPresetId}
+          onPick={(id) => {
+            onSelectPreset(id);
+            setOpen(false);
+          }}
+        />
+      </PopoverContent>
+    </Popover>
+  );
 }
 
 interface StampProps {
@@ -20,7 +242,7 @@ interface StampProps {
 
 export function StampDock({ presets, selectedPresetId, onSelectPreset, onManage }: StampProps) {
   const t = useTranslations();
-  const ordered = orderStampPresets(presets);
+  const { primary, secondary } = splitStampPresets(presets);
 
   return (
     <div
@@ -32,7 +254,7 @@ export function StampDock({ presets, selectedPresetId, onSelectPreset, onManage 
         {t("calendarView.stamp")}
       </span>
       <div className="flex min-w-0 items-center gap-1.5 overflow-x-auto [scrollbar-width:none]">
-        {ordered.length === 0 && (
+        {presets.length === 0 && (
           <button
             type="button"
             onClick={onManage}
@@ -42,7 +264,7 @@ export function StampDock({ presets, selectedPresetId, onSelectPreset, onManage 
             {t("calendarView.createPreset")}
           </button>
         )}
-        {ordered.map((preset, index) => {
+        {primary.map((preset, index) => {
           const active = preset.id === selectedPresetId;
           const key = index < 9 ? String(index + 1) : null;
           return (
@@ -80,6 +302,12 @@ export function StampDock({ presets, selectedPresetId, onSelectPreset, onManage 
           );
         })}
       </div>
+      <MorePresets
+        variant="dock"
+        presets={secondary}
+        selectedPresetId={selectedPresetId}
+        onSelectPreset={onSelectPreset}
+      />
       <div className="mx-0.5 h-[22px] w-px shrink-0 bg-dock-line" />
       <button
         type="button"
@@ -102,14 +330,33 @@ export function MobilePresetBar({
   onAddShift,
 }: StampProps & { onAddShift: () => void }) {
   const t = useTranslations();
-  const ordered = orderStampPresets(presets);
-  const active = ordered.find((p) => p.id === selectedPresetId);
+  const [moreOpen, setMoreOpen] = useState(false);
+  const { primary, secondary } = splitStampPresets(presets);
+  const active = presets.find((p) => p.id === selectedPresetId);
+  const activeSecondary = active?.isSecondary ? active : undefined;
+  // Otherwise the list would pop up by itself once a preset is marked secondary again
+  if (moreOpen && secondary.length === 0) setMoreOpen(false);
 
   return (
     <div className="border-t border-line bg-surface-panel">
+      {moreOpen && (
+        <div className="px-3 pt-2.5">
+          <div className="rounded-[10px] border border-line bg-surface-card p-1">
+            <SecondaryPresetList
+              touch
+              presets={secondary}
+              selectedPresetId={selectedPresetId}
+              onPick={(id) => {
+                onSelectPreset(id);
+                setMoreOpen(false);
+              }}
+            />
+          </div>
+        </div>
+      )}
       <div className="flex items-center gap-2 py-2.5 pl-3 pr-3">
         <div className="flex min-w-0 flex-1 gap-2 overflow-x-auto pb-0.5 [scrollbar-width:thin]">
-          {ordered.length === 0 && (
+          {presets.length === 0 && (
             <button
               type="button"
               onClick={onManage}
@@ -119,7 +366,7 @@ export function MobilePresetBar({
               {t("calendarView.createPreset")}
             </button>
           )}
-          {ordered.map((preset) => {
+          {primary.map((preset) => {
             const on = preset.id === selectedPresetId;
             return (
               <button
@@ -163,6 +410,15 @@ export function MobilePresetBar({
               </button>
             );
           })}
+          {secondary.length > 0 && (
+            <MoreChip
+              variant="bar"
+              count={secondary.length}
+              active={activeSecondary}
+              open={moreOpen}
+              onClick={() => setMoreOpen((current) => !current)}
+            />
+          )}
         </div>
         <button
           type="button"

--- a/messages/cs.json
+++ b/messages/cs.json
@@ -203,7 +203,7 @@
     "presetNamePlaceholder": "např. Ranní směna, večerní směna...",
     "noPresets": "Zatím žádné předvolby směn",
     "deleteConfirm": "Smazat tuto předvolbu? Tím se smažou i všechny směny vytvořené z této předvolby.",
-    "secondary": "Sekundární",
+    "secondary": "Další",
     "hideFromStats": "Skrýt ze statistik"
   },
   "view": {
@@ -243,7 +243,7 @@
     "highlightColor": "Barva zvýraznění",
     "density": "Hustota",
     "showPresetBar": "Zobrazit lištu šablon",
-    "showPresetBarHint": "Lišta razítek pod nebo nad kalendářem"
+    "showPresetBarHint": "Lišta šablon pod nebo nad kalendářem"
   },
   "stats": {
     "title": "Statistiky směn",
@@ -685,7 +685,7 @@
     "external": "externí",
     "syncedReadOnly": "Z externího kalendáře, jen pro čtení",
     "changedOn": "změněno {date}",
-    "stamp": "Razítko",
+    "stamp": "Šablony",
     "managePresets": "Spravovat šablony",
     "createPreset": "Vytvořit šablonu",
     "manage": "Spravovat",
@@ -714,8 +714,8 @@
     "title": "Porovnání",
     "exit": "Ukončit",
     "addCalendar": "Třetí kalendář",
-    "stampActive": "Razítko aktivní",
-    "tapToMoveStamp": "Klepnutím přesunete razítko do tohoto sloupce",
+    "stampActive": "Šablona aktivní",
+    "tapToMoveStamp": "Klikněte na šablonu a vložte ji do tohoto sloupce",
     "subtitle": "{count, plural, one {# kalendář} few {# kalendáře} other {# kalendářů}}",
     "laneHintTwo": "Horní řada {top}, dolní {bottom} — poznáte podle pruhu vlevo. Prázdný rámeček znamená volno.",
     "laneHintMany": "Řady shora: {order} — poznáte podle pruhu vlevo. Prázdný rámeček znamená volno.",
@@ -731,7 +731,7 @@
     "general": "Název a barva",
     "generalHint": "Zobrazovaný název, barva kalendáře, smazání",
     "presets": "Šablony",
-    "presetsHint": "{count, plural, =0 {Zatím žádné šablony} one {# šablona, primární a sekundární} few {# šablony, primární a sekundární} other {# šablon, primární a sekundární}}",
+    "presetsHint": "{count, plural, =0 {Zatím žádné šablony} one {# šablona} few {# šablony} other {# šablon}}",
     "external": "Externí kalendáře",
     "externalHint": "{count, plural, =0 {Odběr, zobrazení, interval} one {# odběr, zobrazení, interval} few {# odběry, zobrazení, interval} other {# odběrů, zobrazení, interval}}",
     "sharing": "Sdílení",
@@ -755,20 +755,22 @@
   },
   "presetSheet": {
     "title": "Předvolby",
-    "description": "Pořadí určuje lištu razítek",
-    "primary": "Primární",
+    "description": "Pořadí určuje lištu šablon",
+    "primary": "V liště",
     "newPreset": "Nová předvolba",
     "titlePlaceholder": "např. Pohotovost",
     "start": "Začátek",
     "end": "Konec",
     "allDay": "Celý den",
     "allDayShort": "celý den",
-    "markAsSecondary": "Označit jako sekundární",
+    "markAsSecondary": "Sbalit pod „Další“",
     "hideFromStatsHint": "Nezapočítává se do hodin ani statistik",
     "notInStats": "Mimo statistiky",
     "save": "Uložit předvolbu",
     "delete": "Smazat předvolbu",
-    "dragHandle": "Přetažením změníte pořadí"
+    "dragHandle": "Přetažením změníte pořadí",
+    "secondarySection": "Pod „Další“",
+    "markAsSecondaryHint": "V liště šablon se zobrazí až po kliknutí na „Další“"
   },
   "syncSheet": {
     "title": "Externí kalendáře",

--- a/messages/de.json
+++ b/messages/de.json
@@ -203,7 +203,7 @@
     "presetNamePlaceholder": "z.B. Frühschicht, Spätschicht...",
     "noPresets": "Noch keine Schichtvorlagen",
     "deleteConfirm": "Diese Vorlage löschen? Alle aus dieser Vorlage erstellten Schichten werden ebenfalls gelöscht.",
-    "secondary": "Sekundär",
+    "secondary": "Weitere",
     "hideFromStats": "Aus Statistik ausblenden"
   },
   "view": {
@@ -243,7 +243,7 @@
     "highlightColor": "Hervorhebungsfarbe",
     "density": "Dichte",
     "showPresetBar": "Vorlagenleiste anzeigen",
-    "showPresetBarHint": "Stempelleiste unter bzw. über dem Kalender"
+    "showPresetBarHint": "Vorlagenleiste unter bzw. über dem Kalender"
   },
   "stats": {
     "title": "Schichtenstatistik",
@@ -685,7 +685,7 @@
     "external": "extern",
     "syncedReadOnly": "Aus einem externen Kalender, nur lesbar",
     "changedOn": "geändert {date}",
-    "stamp": "Stempel",
+    "stamp": "Vorlagen",
     "managePresets": "Vorlagen verwalten",
     "createPreset": "Vorlage anlegen",
     "manage": "Verwalten",
@@ -714,8 +714,8 @@
     "title": "Vergleich",
     "exit": "Beenden",
     "addCalendar": "Dritter Kalender",
-    "stampActive": "Stempel aktiv",
-    "tapToMoveStamp": "Antippen übernimmt den Stempel in diese Spalte",
+    "stampActive": "Vorlage aktiv",
+    "tapToMoveStamp": "Vorlage anklicken, um sie in dieser Spalte zu setzen",
     "subtitle": "{count} Kalender",
     "laneHintTwo": "Obere Reihe {top}, untere {bottom} — erkennbar am Balken links. Leerer Rahmen heißt frei.",
     "laneHintMany": "Reihen von oben: {order} — erkennbar am Balken links. Leerer Rahmen heißt frei.",
@@ -731,7 +731,7 @@
     "general": "Name und Farbe",
     "generalHint": "Anzeigename, Kalenderfarbe, Löschen",
     "presets": "Vorlagen",
-    "presetsHint": "{count, plural, =0 {Noch keine Vorlagen} one {# Vorlage, primär und sekundär} other {# Vorlagen, primär und sekundär}}",
+    "presetsHint": "{count, plural, =0 {Noch keine Vorlagen} one {# Vorlage} other {# Vorlagen}}",
     "external": "Externe Kalender",
     "externalHint": "{count, plural, =0 {Abo, Anzeigemodus, Intervall} one {# Abo, Anzeigemodus, Intervall} other {# Abos, Anzeigemodus, Intervall}}",
     "sharing": "Freigaben",
@@ -755,20 +755,22 @@
   },
   "presetSheet": {
     "title": "Vorlagen",
-    "description": "Reihenfolge bestimmt die Stempelleiste",
-    "primary": "Primär",
+    "description": "Reihenfolge bestimmt die Vorlagenleiste",
+    "primary": "In der Leiste",
     "newPreset": "Neue Vorlage",
     "titlePlaceholder": "z. B. Bereitschaft",
     "start": "Beginn",
     "end": "Ende",
     "allDay": "Ganztägig",
     "allDayShort": "ganztägig",
-    "markAsSecondary": "Als sekundär markieren",
+    "markAsSecondary": "Unter „Weitere“ einklappen",
     "hideFromStatsHint": "Zählt nicht in Stunden und Auswertung",
     "notInStats": "Nicht in Statistik",
     "save": "Vorlage speichern",
     "delete": "Vorlage löschen",
-    "dragHandle": "Zum Sortieren ziehen"
+    "dragHandle": "Zum Sortieren ziehen",
+    "secondarySection": "Unter „Weitere“",
+    "markAsSecondaryHint": "Erscheint in der Vorlagenleiste erst nach Klick auf „Weitere“"
   },
   "syncSheet": {
     "title": "Externe Kalender",

--- a/messages/en.json
+++ b/messages/en.json
@@ -203,7 +203,7 @@
     "presetNamePlaceholder": "e.g., Morning Shift, Evening Shift...",
     "noPresets": "No shift presets yet",
     "deleteConfirm": "Delete this preset? This will also delete all shifts created from this preset.",
-    "secondary": "Secondary",
+    "secondary": "More",
     "hideFromStats": "Hide from statistics"
   },
   "view": {
@@ -243,7 +243,7 @@
     "highlightColor": "Highlight Color",
     "density": "Density",
     "showPresetBar": "Show preset bar",
-    "showPresetBarHint": "Stamp bar below or above the calendar"
+    "showPresetBarHint": "Preset bar below or above the calendar"
   },
   "stats": {
     "title": "Shift Statistics",
@@ -685,7 +685,7 @@
     "external": "external",
     "syncedReadOnly": "From an external calendar, read-only",
     "changedOn": "changed {date}",
-    "stamp": "Stamp",
+    "stamp": "Presets",
     "managePresets": "Manage presets",
     "createPreset": "Create preset",
     "manage": "Manage",
@@ -714,8 +714,8 @@
     "title": "Compare",
     "exit": "Exit",
     "addCalendar": "Third calendar",
-    "stampActive": "Stamp active",
-    "tapToMoveStamp": "Tap to move the stamp to this column",
+    "stampActive": "Preset active",
+    "tapToMoveStamp": "Click a preset to place it in this column",
     "subtitle": "{count} calendars",
     "laneHintTwo": "Top row {top}, bottom row {bottom} — see the bar on the left. An empty frame means off.",
     "laneHintMany": "Rows from the top: {order} — see the bar on the left. An empty frame means off.",
@@ -731,7 +731,7 @@
     "general": "Name and color",
     "generalHint": "Display name, calendar color, delete",
     "presets": "Presets",
-    "presetsHint": "{count, plural, =0 {No presets yet} one {# preset, primary and secondary} other {# presets, primary and secondary}}",
+    "presetsHint": "{count, plural, =0 {No presets yet} one {# preset} other {# presets}}",
     "external": "External calendars",
     "externalHint": "{count, plural, =0 {Subscription, display mode, interval} one {# subscription, display mode, interval} other {# subscriptions, display mode, interval}}",
     "sharing": "Sharing",
@@ -755,20 +755,22 @@
   },
   "presetSheet": {
     "title": "Presets",
-    "description": "The order sets the stamp bar",
-    "primary": "Primary",
+    "description": "The order sets the preset bar",
+    "primary": "In the bar",
     "newPreset": "New preset",
     "titlePlaceholder": "e.g. On call",
     "start": "Start",
     "end": "End",
     "allDay": "All day",
     "allDayShort": "all day",
-    "markAsSecondary": "Mark as secondary",
+    "markAsSecondary": "Tuck under “More”",
     "hideFromStatsHint": "Not counted in hours and statistics",
     "notInStats": "Not in statistics",
     "save": "Save preset",
     "delete": "Delete preset",
-    "dragHandle": "Drag to reorder"
+    "dragHandle": "Drag to reorder",
+    "secondarySection": "Under “More”",
+    "markAsSecondaryHint": "Shows in the preset bar only after clicking “More”"
   },
   "syncSheet": {
     "title": "External calendars",

--- a/messages/es.json
+++ b/messages/es.json
@@ -203,7 +203,7 @@
     "presetNamePlaceholder": "ej., Turno de mañana, Turno de tarde...",
     "noPresets": "Aún no hay preajustes de turno",
     "deleteConfirm": "¿Eliminar este preajuste? Esto también eliminará todos los turnos creados a partir de él.",
-    "secondary": "Secundario",
+    "secondary": "Más",
     "hideFromStats": "Ocultar de las estadísticas"
   },
   "view": {
@@ -243,7 +243,7 @@
     "highlightColor": "Color de resaltado",
     "density": "Densidad",
     "showPresetBar": "Mostrar barra de plantillas",
-    "showPresetBarHint": "Barra de sellos debajo o encima del calendario"
+    "showPresetBarHint": "Barra de plantillas debajo o encima del calendario"
   },
   "stats": {
     "title": "Estadísticas de turnos",
@@ -685,7 +685,7 @@
     "external": "externo",
     "syncedReadOnly": "De un calendario externo, solo lectura",
     "changedOn": "modificado {date}",
-    "stamp": "Sello",
+    "stamp": "Plantillas",
     "managePresets": "Gestionar plantillas",
     "createPreset": "Crear plantilla",
     "manage": "Gestionar",
@@ -714,8 +714,8 @@
     "title": "Comparar",
     "exit": "Salir",
     "addCalendar": "Tercer calendario",
-    "stampActive": "Sello activo",
-    "tapToMoveStamp": "Toca para mover el sello a esta columna",
+    "stampActive": "Plantilla activa",
+    "tapToMoveStamp": "Haz clic en una plantilla para ponerla en esta columna",
     "subtitle": "{count} calendarios",
     "laneHintTwo": "Fila superior {top}, inferior {bottom}; se distinguen por la barra izquierda. Un marco vacío significa libre.",
     "laneHintMany": "Filas desde arriba: {order}; se distinguen por la barra izquierda. Un marco vacío significa libre.",
@@ -731,7 +731,7 @@
     "general": "Nombre y color",
     "generalHint": "Nombre visible, color del calendario, eliminar",
     "presets": "Plantillas",
-    "presetsHint": "{count, plural, =0 {Aún no hay plantillas} one {# plantilla, primaria y secundaria} other {# plantillas, primarias y secundarias}}",
+    "presetsHint": "{count, plural, =0 {Aún no hay plantillas} one {# plantilla} other {# plantillas}}",
     "external": "Calendarios externos",
     "externalHint": "{count, plural, =0 {Suscripción, modo de vista, intervalo} one {# suscripción, modo de vista, intervalo} other {# suscripciones, modo de vista, intervalo}}",
     "sharing": "Compartir",
@@ -755,20 +755,22 @@
   },
   "presetSheet": {
     "title": "Preajustes",
-    "description": "El orden define la barra de sellos",
-    "primary": "Principal",
+    "description": "El orden define la barra de plantillas",
+    "primary": "En la barra",
     "newPreset": "Nuevo preajuste",
     "titlePlaceholder": "p. ej. Guardia",
     "start": "Inicio",
     "end": "Fin",
     "allDay": "Todo el día",
     "allDayShort": "todo el día",
-    "markAsSecondary": "Marcar como secundario",
+    "markAsSecondary": "Agrupar en «Más»",
     "hideFromStatsHint": "No cuenta en horas ni estadísticas",
     "notInStats": "Fuera de estadísticas",
     "save": "Guardar preajuste",
     "delete": "Eliminar preajuste",
-    "dragHandle": "Arrastrar para ordenar"
+    "dragHandle": "Arrastrar para ordenar",
+    "secondarySection": "En «Más»",
+    "markAsSecondaryHint": "Aparece en la barra de plantillas solo al pulsar «Más»"
   },
   "syncSheet": {
     "title": "Calendarios externos",

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -203,7 +203,7 @@
     "presetNamePlaceholder": "ex. : Créneau matin, Créneau soir...",
     "noPresets": "Aucun modèle de créneau pour l'instant",
     "deleteConfirm": "Supprimer ce modèle ? Tous les créneaux créés à partir de ce modèle seront également supprimés.",
-    "secondary": "Secondaire",
+    "secondary": "Plus",
     "hideFromStats": "Exclure des statistiques"
   },
   "view": {
@@ -243,7 +243,7 @@
     "highlightColor": "Couleur de mise en évidence",
     "density": "Densité",
     "showPresetBar": "Afficher la barre de modèles",
-    "showPresetBarHint": "Barre de tampons sous ou au-dessus du calendrier"
+    "showPresetBarHint": "Barre de modèles sous ou au-dessus du calendrier"
   },
   "stats": {
     "title": "Statistiques des créneaux",
@@ -685,7 +685,7 @@
     "external": "externe",
     "syncedReadOnly": "Depuis un calendrier externe, lecture seule",
     "changedOn": "modifié le {date}",
-    "stamp": "Tampon",
+    "stamp": "Modèles",
     "managePresets": "Gérer les modèles",
     "createPreset": "Créer un modèle",
     "manage": "Gérer",
@@ -714,8 +714,8 @@
     "title": "Comparer",
     "exit": "Quitter",
     "addCalendar": "Troisième calendrier",
-    "stampActive": "Tampon actif",
-    "tapToMoveStamp": "Touchez pour déplacer le tampon dans cette colonne",
+    "stampActive": "Modèle actif",
+    "tapToMoveStamp": "Cliquez sur un modèle pour le placer dans cette colonne",
     "subtitle": "{count} calendriers",
     "laneHintTwo": "Ligne du haut {top}, du bas {bottom} — repérable à la barre de gauche. Un cadre vide signifie libre.",
     "laneHintMany": "Lignes depuis le haut : {order} — repérables à la barre de gauche. Un cadre vide signifie libre.",
@@ -731,7 +731,7 @@
     "general": "Nom et couleur",
     "generalHint": "Nom affiché, couleur du calendrier, suppression",
     "presets": "Modèles",
-    "presetsHint": "{count, plural, =0 {Aucun modèle} one {# modèle, principal et secondaire} other {# modèles, principaux et secondaires}}",
+    "presetsHint": "{count, plural, =0 {Aucun modèle} one {# modèle} other {# modèles}}",
     "external": "Calendriers externes",
     "externalHint": "{count, plural, =0 {Abonnement, affichage, intervalle} one {# abonnement, affichage, intervalle} other {# abonnements, affichage, intervalle}}",
     "sharing": "Partage",
@@ -755,20 +755,22 @@
   },
   "presetSheet": {
     "title": "Modèles",
-    "description": "L’ordre définit la barre de tampons",
-    "primary": "Principal",
+    "description": "L’ordre définit la barre de modèles",
+    "primary": "Dans la barre",
     "newPreset": "Nouveau modèle",
     "titlePlaceholder": "p. ex. Astreinte",
     "start": "Début",
     "end": "Fin",
     "allDay": "Toute la journée",
     "allDayShort": "toute la journée",
-    "markAsSecondary": "Marquer comme secondaire",
+    "markAsSecondary": "Ranger sous « Plus »",
     "hideFromStatsHint": "Non compté dans les heures ni les statistiques",
     "notInStats": "Hors statistiques",
     "save": "Enregistrer le modèle",
     "delete": "Supprimer le modèle",
-    "dragHandle": "Glisser pour réordonner"
+    "dragHandle": "Glisser pour réordonner",
+    "secondarySection": "Sous « Plus »",
+    "markAsSecondaryHint": "N’apparaît dans la barre de modèles qu’après un clic sur « Plus »"
   },
   "syncSheet": {
     "title": "Calendriers externes",

--- a/messages/it.json
+++ b/messages/it.json
@@ -203,7 +203,7 @@
     "presetNamePlaceholder": "es., Turno Mattutino, Turno Serale...",
     "noPresets": "Ancora nessun preset turno",
     "deleteConfirm": "Eliminare questo preset? Verranno eliminati anche tutti i turni creati da questo preset.",
-    "secondary": "Secondario",
+    "secondary": "Altri",
     "hideFromStats": "Nascondi dalle statistiche"
   },
   "view": {
@@ -243,7 +243,7 @@
     "highlightColor": "Colore Evidenziazione",
     "density": "Densità",
     "showPresetBar": "Mostra barra dei modelli",
-    "showPresetBarHint": "Barra dei timbri sotto o sopra il calendario"
+    "showPresetBarHint": "Barra dei modelli sotto o sopra il calendario"
   },
   "stats": {
     "title": "Statistiche Turni",
@@ -685,7 +685,7 @@
     "external": "esterno",
     "syncedReadOnly": "Da un calendario esterno, sola lettura",
     "changedOn": "modificato il {date}",
-    "stamp": "Timbro",
+    "stamp": "Modelli",
     "managePresets": "Gestisci modelli",
     "createPreset": "Crea modello",
     "manage": "Gestisci",
@@ -714,8 +714,8 @@
     "title": "Confronto",
     "exit": "Esci",
     "addCalendar": "Terzo calendario",
-    "stampActive": "Timbro attivo",
-    "tapToMoveStamp": "Tocca per spostare il timbro in questa colonna",
+    "stampActive": "Modello attivo",
+    "tapToMoveStamp": "Clicca un modello per inserirlo in questa colonna",
     "subtitle": "{count} calendari",
     "laneHintTwo": "Riga in alto {top}, in basso {bottom}: si riconoscono dalla barra a sinistra. Un riquadro vuoto significa libero.",
     "laneHintMany": "Righe dall’alto: {order}: si riconoscono dalla barra a sinistra. Un riquadro vuoto significa libero.",
@@ -731,7 +731,7 @@
     "general": "Nome e colore",
     "generalHint": "Nome visualizzato, colore del calendario, eliminazione",
     "presets": "Modelli",
-    "presetsHint": "{count, plural, =0 {Nessun modello} one {# modello, primario e secondario} other {# modelli, primari e secondari}}",
+    "presetsHint": "{count, plural, =0 {Nessun modello} one {# modello} other {# modelli}}",
     "external": "Calendari esterni",
     "externalHint": "{count, plural, =0 {Abbonamento, visualizzazione, intervallo} one {# abbonamento, visualizzazione, intervallo} other {# abbonamenti, visualizzazione, intervallo}}",
     "sharing": "Condivisione",
@@ -755,20 +755,22 @@
   },
   "presetSheet": {
     "title": "Preset",
-    "description": "L’ordine determina la barra dei timbri",
-    "primary": "Primario",
+    "description": "L’ordine determina la barra dei modelli",
+    "primary": "Nella barra",
     "newPreset": "Nuovo preset",
     "titlePlaceholder": "es. Reperibilità",
     "start": "Inizio",
     "end": "Fine",
     "allDay": "Tutto il giorno",
     "allDayShort": "tutto il giorno",
-    "markAsSecondary": "Segna come secondario",
+    "markAsSecondary": "Raggruppa sotto «Altri»",
     "hideFromStatsHint": "Non conta nelle ore né nelle statistiche",
     "notInStats": "Escluso dalle statistiche",
     "save": "Salva preset",
     "delete": "Elimina preset",
-    "dragHandle": "Trascina per riordinare"
+    "dragHandle": "Trascina per riordinare",
+    "secondarySection": "Sotto «Altri»",
+    "markAsSecondaryHint": "Compare nella barra dei modelli solo dopo aver cliccato «Altri»"
   },
   "syncSheet": {
     "title": "Calendari esterni",


### PR DESCRIPTION
## What

Addresses the product owner's review note on presets in the redesign (unit 1 of the feedback batch, stacked on #176).

**Preset bar: secondary presets behind "Weitere"**
- The desktop dock, the phone preset bar and the compare-mode chip rows now show only primary presets. Number keys 1–9 map to primary presets only.
- If a calendar has at least one secondary preset, a trailing **"Weitere · N"** chip appears:
  - **Desktop dock:** it opens a popover above the dock that lists the secondary presets (colour dot, title, time; the armed one gets a check mark). Picking one arms it and closes the popover. Picking the armed one disarms it.
  - **Compare columns:** the same popover opens below the chip. Primary chips now clip in their own container, so "Weitere" and the manage button stay visible in narrow columns.
  - **Phone:** tapping the chip expands a compact list with touch-sized rows directly above the bar. Picking a preset arms it and collapses the list.
- While a secondary preset is armed, the chip shows that preset in the active style (dot + name, or code tile + time on phones). The chip stays in the same place, so the primary chips don't move.
- One shared piece in `stamp-dock.tsx` (`MoreChip` + `SecondaryPresetList`, wrapped by `MorePresets` for the popover) is used in all three places.

**Management wording**
- The section labels are now "In der Leiste" and "Unter „Weitere“".
- The row pill is now a neutral "Weitere" instead of an amber "Sekundär".
- The form checkbox is now "Unter „Weitere“ einklappen", with the hint "Erscheint in der Vorlagenleiste erst nach Klick auf „Weitere“".
- `settings.presetsHint` no longer says "primär und sekundär".

**"Stempel" → "Vorlage"**
- Every user-visible stamp string (`calendarView.stamp`, `calendarCompare.stampActive`, `calendarCompare.tapToMoveStamp`, `presetSheet.description`, `view.showPresetBarHint`) now says Vorlage/Vorlagenleiste. The other locales use their existing preset term.
- The keys are unchanged; only the values changed.

## Why

The redesign rendered secondary presets inline like any other preset, so the primary/secondary flag had no visible effect. This restores the pre-redesign meaning: secondary presets are collapsed behind a toggle. The "Stempel" metaphor confused users; the rest of the app already calls these "Vorlagen".

## Notes
- The i18n keys are unchanged apart from two additions: `presetSheet.secondarySection` and `presetSheet.markAsSecondaryHint`. `preset.secondary` now holds the "Weitere" label, and the chip and the pill both use it, so the two always match.
- es/it/cs use two terms for presets: `preajuste`/`preset`/`předvolba` in the older `preset.*` keys, and `plantilla`/`modello`/`šablona` in the dock, view settings and settings nav. The renamed bar strings follow the latter, so they match their neighbours ("Crear plantilla", "Mostrar barra de plantillas"). I did not unify the older keys.
- Checks run: `npx tsc --noEmit`, `npm run lint` and `npm run i18n` (100 %, 0 unused). No build and no visual check in this worker; that verification is still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MSpX5Vc9i4MHxAS3eFHS2X
