### PR TITLE
fix: mobile input zoom, CSP nonce, Docker path/persistence, and calendar bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,8 +80,6 @@ public/workbox-*.js.map
 
 # Local scripts
 .LOCAL
-# Claude Code agent worktrees (nested checkouts, never commit)
-.claude/worktrees/
+.claude/
 
-# Playwright MCP output directory
 .playwright-mcp/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,10 @@ There is no unit-test framework here — "tests" means the lint/build/i18n pipel
 
 `npm run release:patch|minor|major` bumps the version and pushes the tag; the release workflow builds the image from it.
 
+## Workflow
+
+Commits follow Conventional Commits (`type(scope): summary`, e.g. `feat(ui):`, `fix(auth):`, `chore:`, `perf:`; `!` before the colon for breaking changes). `scripts/changelog.sh`, called from `.github/workflows/release.yml`, builds the release changelog straight from `git log --pretty=%s --no-merges` between tags — grouped by that prefix, with `refactor|ci|style|test|build` dropped as internal-only. It reads commit subjects, not the PR title or body, so **multi-commit PRs must merge via "Rebase and merge", not Squash** — squashing collapses every commit into one line under the merge commit's message and the per-commit changelog entries are lost. A single-commit PR can go either way since there's nothing to collapse.
+
 ## Architecture
 
 ### Request flow

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ _BetterShift is a self-hosted shift management application for teams and individ
 docker run -d \
   -p 3000:3000 \
   -v ./data:/app/data \
+  -v ./uploads:/app/public/uploads \
   -e BETTER_AUTH_SECRET=$(openssl rand -base64 32) \
   -e BETTER_AUTH_URL=http://localhost:3000 \
   -e TZ=Europe/Berlin \

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata, Viewport } from "next";
 import { IBM_Plex_Sans, IBM_Plex_Mono } from "next/font/google";
+import { headers } from "next/headers";
 import { NextIntlClientProvider } from "next-intl";
 import { getMessages, getLocale } from "next-intl/server";
 import { ThemeProvider } from "@/components/theme-provider";
@@ -71,12 +72,14 @@ export default async function RootLayout({
   const locale = await getLocale();
   const messages = await getMessages();
   const publicConfig = getPublicConfig();
+  const nonce = (await headers()).get("x-nonce") || undefined;
 
   return (
     <html lang={locale} suppressHydrationWarning>
       <head>
         {/* Inject public config for immediate client-side access (zero latency) */}
         <script
+          nonce={nonce}
           dangerouslySetInnerHTML={{
             __html: `window.__PUBLIC_CONFIG__=${JSON.stringify(publicConfig)};`,
           }}
@@ -90,6 +93,7 @@ export default async function RootLayout({
           defaultTheme="system"
           enableSystem
           disableTransitionOnChange
+          nonce={nonce}
         >
           <NextIntlClientProvider messages={messages} locale={locale}>
             <QueryProvider>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -202,6 +202,8 @@ function HomeContent() {
           calendars.some((cal) => cal.id === id)
         );
         if (validIds.length >= 2) {
+          // Syncing from the URL (an external source), not from render state.
+          // eslint-disable-next-line react-hooks/set-state-in-effect
           setSelectedCompareIds(validIds);
           setIsCompareMode(true);
         }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,15 +3,14 @@
 import { useState, useEffect, Suspense, useCallback, useMemo } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useTranslations } from "next-intl";
-import { isSameDay, isSameMonth } from "date-fns";
-import { toast } from "sonner";
+import { isSameMonth } from "date-fns";
 import { ShiftWithCalendar } from "@/lib/types";
 import { CalendarNote } from "@/lib/db/schema";
 import { useCalendars } from "@/hooks/useCalendars";
 import { useShifts } from "@/hooks/useShifts";
 import { usePresets } from "@/hooks/usePresets";
 import { useNotes } from "@/hooks/useNotes";
-import { useCompareData } from "@/hooks/useCompareData";
+import { useCompareMode } from "@/hooks/useCompareMode";
 import { useViewSettings } from "@/hooks/useViewSettings";
 import { useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "@/lib/query-keys";
@@ -46,12 +45,6 @@ function toDayLayout(view: CalendarViewSettings): DayLayoutOptions {
     sortOrder: view.sortOrder,
     combinedSort: view.combinedSort,
   };
-}
-
-function toDate(date: Date | string): Date {
-  return typeof date === "string" && /^\d{4}-\d{2}-\d{2}$/.test(date)
-    ? parseLocalDate(date)
-    : new Date(date);
 }
 
 function HomeContent() {
@@ -95,9 +88,6 @@ function HomeContent() {
   const [selectedPresetId, setSelectedPresetId] = useState<string | undefined>();
   const [currentDate, setCurrentDate] = useState(new Date());
   const [selectedDate, setSelectedDate] = useState<Date | undefined>();
-  const [compareNoteCalendarId, setCompareNoteCalendarId] = useState<
-    string | undefined
-  >();
   const [editingShift, setEditingShift] = useState<ShiftWithCalendar | undefined>();
   const [daySheetOpen, setDaySheetOpen] = useState(false);
 
@@ -115,20 +105,32 @@ function HomeContent() {
     [selectedCalendar]
   );
 
-  const [isCompareMode, setIsCompareMode] = useState(false);
-  const [showCompareSelector, setShowCompareSelector] = useState(false);
-  const [selectedCompareIds, setSelectedCompareIds] = useState<string[]>([]);
-  // Selection before the picker opened, restored on cancel
-  const [compareSnapshot, setCompareSnapshot] = useState<string[]>([]);
-  const [compareTogglingDates, setCompareTogglingDates] = useState<
-    Map<string, Set<string>>
-  >(new Map());
-
   const queryClient = useQueryClient();
 
-  const compareData = useCompareData({
-    calendarIds: selectedCompareIds,
-    enabled: isCompareMode,
+  const {
+    isCompareMode,
+    setIsCompareMode,
+    showCompareSelector,
+    setShowCompareSelector,
+    selectedCompareIds,
+    setSelectedCompareIds,
+    compareSnapshot,
+    compareTogglingDates,
+    compareNoteCalendarId,
+    setCompareNoteCalendarId,
+    compareData,
+    handleToggleCompareCalendar,
+    handleExitCompare,
+    openComparePicker,
+    handleCompareDayClick,
+  } = useCompareMode({
+    calendars,
+    hasLoadedOnce,
+    selectedCalendar,
+    currentDate,
+    setCurrentDate,
+    selectDay,
+    selectedPresetId,
   });
 
   const {
@@ -192,48 +194,10 @@ function HomeContent() {
     dialogStates.setShowDayShiftsDialog(true);
   };
 
-  // Load compare mode from URL on initial load
-  useEffect(() => {
-    const compareParam = searchParams.get("compare");
-    if (compareParam && !isCompareMode) {
-      const calendarIds = compareParam.split(",").filter((id) => id.trim());
-      if (calendarIds.length >= 2 && calendarIds.length <= 3) {
-        const validIds = calendarIds.filter((id) =>
-          calendars.some((cal) => cal.id === id)
-        );
-        if (validIds.length >= 2) {
-          // Syncing from the URL (an external source), not from render state.
-          // eslint-disable-next-line react-hooks/set-state-in-effect
-          setSelectedCompareIds(validIds);
-          setIsCompareMode(true);
-        }
-      }
-    } else if (!compareParam && isCompareMode) {
-      setIsCompareMode(false);
-      setSelectedCompareIds([]);
-      setCompareTogglingDates(new Map());
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [searchParams, calendars]);
-
-  // The effect above only filters while entering compare mode. Access to one of
-  // the columns can be lost afterwards, and compare needs at least two.
-  useEffect(() => {
-    if (!isCompareMode || !hasLoadedOnce) return;
-    const stillAccessible = selectedCompareIds.filter((id) =>
-      calendars.some((cal) => cal.id === id)
-    );
-    if (stillAccessible.length === selectedCompareIds.length) return;
-    queueMicrotask(() => {
-      if (stillAccessible.length >= 2) {
-        setSelectedCompareIds(stillAccessible);
-      } else {
-        setIsCompareMode(false);
-        setSelectedCompareIds([]);
-        setCompareTogglingDates(new Map());
-      }
-    });
-  }, [isCompareMode, hasLoadedOnce, calendars, selectedCompareIds]);
+  const openCompareNotes = (calendarId: string, date: Date) => {
+    setCompareNoteCalendarId(calendarId);
+    openNotesForDay(compareData.notesMap.get(calendarId) || [], date);
+  };
 
   useEffect(() => {
     if (isCompareMode && selectedCompareIds.length >= 2) {
@@ -320,95 +284,6 @@ function HomeContent() {
     } else if (!desktop) {
       setDaySheetOpen(true);
     }
-  };
-
-  // Compare mode handlers
-  const handleToggleCompareCalendar = (calendarId: string) => {
-    setSelectedCompareIds((prev) =>
-      prev.includes(calendarId)
-        ? prev.filter((id) => id !== calendarId)
-        : [...prev, calendarId]
-    );
-  };
-
-  const handleExitCompare = () => {
-    setIsCompareMode(false);
-    setSelectedCompareIds([]);
-    setCompareTogglingDates(new Map());
-    router.replace(selectedCalendar ? `/?id=${selectedCalendar}` : `/`, {
-      scroll: false,
-    });
-  };
-
-  const updateCompareToggling = (calendarId: string, dateKey: string, add: boolean) => {
-    setCompareTogglingDates((prev) => {
-      const updated = new Map(prev);
-      const next = new Set(updated.get(calendarId) || []);
-      if (add) next.add(dateKey);
-      else next.delete(dateKey);
-      updated.set(calendarId, next);
-      return updated;
-    });
-  };
-
-  const openComparePicker = () => {
-    setCompareSnapshot(isCompareMode ? selectedCompareIds : []);
-    setShowCompareSelector(true);
-  };
-
-  const handleCompareDayClick = async (calendarId: string, date: Date | string) => {
-    const targetDate = toDate(date);
-    selectDay(targetDate);
-    if (!isSameMonth(targetDate, currentDate)) setCurrentDate(targetDate);
-    if (!selectedPresetId) return;
-
-    const calendarPresets = compareData.presetsMap.get(calendarId) || [];
-    const calendarShifts = compareData.shiftsMap.get(calendarId) || [];
-    const preset = calendarPresets.find((p) => p.id === selectedPresetId);
-    if (!preset) return;
-
-    const dateKey = formatDateToLocal(targetDate);
-    if (compareTogglingDates.get(calendarId)?.has(dateKey)) return;
-    updateCompareToggling(calendarId, dateKey, true);
-
-    try {
-      const existingShift = calendarShifts.find(
-        (shift) =>
-          shift.date &&
-          isSameDay(shift.date as Date, targetDate) &&
-          shift.title === preset.title &&
-          shift.startTime === preset.startTime &&
-          shift.endTime === preset.endTime
-      );
-
-      if (existingShift) {
-        await compareData.deleteShift({ calendarId, shiftId: existingShift.id });
-      } else {
-        await compareData.createShift({
-          calendarId,
-          formData: {
-            date: dateKey,
-            startTime: preset.startTime,
-            endTime: preset.endTime,
-            title: preset.title,
-            color: preset.color,
-            notes: preset.notes || "",
-            presetId: preset.id,
-            isAllDay: preset.isAllDay || false,
-          },
-        });
-      }
-    } catch (error) {
-      console.error("Failed to toggle shift:", error);
-      toast.error(t("common.error"));
-    } finally {
-      updateCompareToggling(calendarId, dateKey, false);
-    }
-  };
-
-  const openCompareNotes = (calendarId: string, date: Date) => {
-    setCompareNoteCalendarId(calendarId);
-    openNotesForDay(compareData.notesMap.get(calendarId) || [], date);
   };
 
   const dialogManager = (

--- a/components/external-sync-manage-sheet.tsx
+++ b/components/external-sync-manage-sheet.tsx
@@ -1,24 +1,13 @@
 "use client";
 
-import { useState, useMemo } from "react";
 import { useTranslations } from "next-intl";
 import { Loader2, Plus } from "lucide-react";
-import { toast } from "sonner";
-import { ExternalSync } from "@/lib/db/schema";
 import { Button } from "@/components/ui/button";
 import { ConfirmationDialog } from "@/components/ui/confirmation-dialog";
 import { PanelBody, PanelFooter } from "@/components/panel-dialog";
 import { ExternalSyncRow } from "@/components/external-sync-list";
 import { ExternalSyncForm } from "@/components/external-sync-form";
-import { syncToFormValues, useExternalSyncForm } from "@/hooks/useExternalSyncForm";
-import { useExternalSync } from "@/hooks/useExternalSync";
-import { isRateLimitError, handleRateLimitError } from "@/lib/rate-limit-client";
-import { isValidCalendarUrl, detectCalendarSyncType } from "@/lib/external-calendar-utils";
-import { useGuardedAction, useReportDirty } from "@/hooks/useDirtyState";
-
-const MAX_FILE_SIZE = 5 * 1024 * 1024;
-
-type PanelMode = { kind: "list" } | { kind: "add" } | { kind: "edit"; syncId: string };
+import { useExternalSyncPanel } from "@/hooks/useExternalSyncPanel";
 
 interface ExternalSyncPanelProps {
   calendarId: string;
@@ -35,248 +24,36 @@ export function ExternalSyncPanel({
   onDirtyChange,
 }: ExternalSyncPanelProps) {
   const t = useTranslations();
-  const [mode, setMode] = useState<PanelMode>({ kind: "list" });
-  const [isSyncing, setIsSyncing] = useState<string | null>(null);
-  const [isDeleting, setIsDeleting] = useState<string | null>(null);
-  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const { values, setField, reset, isDirty } = useExternalSyncForm();
-  const itemLabel = t("externalSync.syncTypeCustom");
-
-  const { externalSyncs: syncs, syncLogs, refetch: invalidateSyncs } = useExternalSync(calendarId);
-
-  // Latest unread error per sync; marking logs as read clears it.
-  const syncErrors = useMemo(() => {
-    const errors: Record<string, string> = {};
-    for (const sync of syncs) {
-      const latestError = syncLogs.find(
-        (log) => log.externalSyncId === sync.id && log.status === "error" && !log.isRead
-      );
-      if (latestError) {
-        errors[sync.id] = latestError.errorMessage || t("syncNotifications.statusError");
-      }
-    }
-    return errors;
-  }, [syncs, syncLogs, t]);
-
-  const editingSync =
-    mode.kind === "edit" ? syncs.find((sync) => sync.id === mode.syncId) ?? null : null;
-  const formOpen = mode.kind === "add" || editingSync !== null;
-
-  const hasUnsavedChanges = formOpen && isDirty;
-
-  useReportDirty(hasUnsavedChanges, onDirtyChange);
-
-  const showList = () => {
-    setMode({ kind: "list" });
-    reset();
-  };
-
-  const startAdd = () => {
-    setMode({ kind: "add" });
-    reset();
-  };
-
-  const startEdit = (sync: ExternalSync) => {
-    setMode({ kind: "edit", syncId: sync.id });
-    reset(syncToFormValues(sync));
-  };
-
-  /** Runs `action` right away, or after confirming that unsaved input may be dropped. */
-  const { guarded: guardUnsaved, confirmProps } = useGuardedAction(hasUnsavedChanges);
-
-  const handleSync = async (syncId: string) => {
-    setIsSyncing(syncId);
-    try {
-      const response = await fetch(`/api/external-syncs/${syncId}/sync`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
-      });
-
-      if (isRateLimitError(response)) {
-        await handleRateLimitError(response, t);
-        return;
-      }
-
-      const data = await response.json();
-      if (!response.ok) {
-        throw new Error(data.error || "Failed to sync calendar");
-      }
-
-      invalidateSyncs();
-      onSyncComplete?.();
-
-      const stats = data.stats || { created: 0, updated: 0, deleted: 0 };
-      toast.success(
-        `${t("common.success")}: ${t("common.createdCount", {
-          count: stats.created,
-        })}, ${t("common.updatedCount", {
-          count: stats.updated,
-        })}, ${t("common.deletedCount", { count: stats.deleted })}`
-      );
-    } catch (error) {
-      console.error("Sync error:", error);
-      toast.error(error instanceof Error ? error.message : t("common.error"));
-    } finally {
-      setIsSyncing(null);
-    }
-  };
-
-  const handleAdd = async () => {
-    const name = values.name.trim();
-    const url = values.url.trim();
-    if (!name) return;
-
-    if (values.importType === "file") {
-      if (!values.file) {
-        toast.error(t("validation.fileRequired"));
-        return;
-      }
-      if (values.file.size > MAX_FILE_SIZE) {
-        toast.error(t("validation.fileTooLarge", { maxSize: "5MB" }));
-        return;
-      }
-    } else {
-      if (!url) {
-        toast.error(t("validation.urlRequired"));
-        return;
-      }
-      if (!isValidCalendarUrl(url, detectCalendarSyncType(url))) {
-        toast.error(t("validation.urlInvalid"));
-        return;
-      }
-      // Uploaded files are stored as data URLs and never collide.
-      const exists = syncs.some(
-        (sync) => !sync.isOneTimeImport && sync.calendarUrl.toLowerCase() === url.toLowerCase()
-      );
-      if (exists) {
-        toast.error(t("validation.urlAlreadyExists"));
-        return;
-      }
-    }
-
-    setIsSubmitting(true);
-    try {
-      const icsContent =
-        values.importType === "file" && values.file ? await values.file.text() : undefined;
-
-      const response = await fetch("/api/external-syncs", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          calendarId,
-          name,
-          calendarUrl: url || undefined,
-          color: values.color,
-          displayMode: values.displayMode,
-          autoSyncInterval: values.autoSyncInterval,
-          icsContent,
-          isHidden: values.isHidden,
-          hideFromStats: values.hideFromStats,
-        }),
-      });
-
-      if (response.ok) {
-        const newSync = await response.json();
-        showList();
-        invalidateSyncs();
-        onSyncComplete?.();
-        toast.success(t("common.created", { item: itemLabel }));
-        await handleSync(newSync.id);
-      } else {
-        const data = await response.json();
-        toast.error(data.error || t("common.createError", { item: itemLabel }));
-      }
-    } catch (error) {
-      console.error("Failed to create sync:", error);
-      toast.error(t("common.createError", { item: itemLabel }));
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const handleSave = async () => {
-    if (!editingSync) return;
-
-    setIsSubmitting(true);
-    try {
-      const response = await fetch(`/api/external-syncs/${editingSync.id}`, {
-        method: "PATCH",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name: values.name.trim(),
-          calendarUrl: !editingSync.isOneTimeImport ? values.url.trim() : undefined,
-          color: values.color,
-          displayMode: values.displayMode,
-          autoSyncInterval: values.autoSyncInterval,
-          isHidden: values.isHidden,
-          hideFromStats: values.hideFromStats,
-        }),
-      });
-
-      if (response.ok) {
-        invalidateSyncs();
-        onSyncComplete?.();
-        showList();
-        toast.success(t("common.updated", { item: itemLabel }));
-      } else {
-        const data = await response.json();
-        toast.error(data.error || t("common.updateError", { item: itemLabel }));
-      }
-    } catch (error) {
-      console.error("Failed to save sync:", error);
-      toast.error(t("common.updateError", { item: itemLabel }));
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
-
-  const confirmDelete = async () => {
-    const syncId = deleteTargetId;
-    if (!syncId) return;
-
-    setIsDeleting(syncId);
-    try {
-      const response = await fetch(`/api/external-syncs/${syncId}`, {
-        method: "DELETE",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({}),
-      });
-
-      if (response.ok) {
-        if (mode.kind === "edit" && mode.syncId === syncId) showList();
-        invalidateSyncs();
-        onSyncComplete?.();
-        toast.success(t("common.deleted", { item: itemLabel }));
-      } else {
-        const data = await response.json();
-        toast.error(data.error || t("common.deleteError", { item: itemLabel }));
-      }
-    } catch (error) {
-      console.error("Error deleting sync:", error);
-      toast.error(t("common.deleteError", { item: itemLabel }));
-    } finally {
-      setIsDeleting(null);
-      setDeleteTargetId(null);
-    }
-  };
-
-  const busy = !!isSyncing || !!isDeleting;
-  const canSubmit =
-    !isSubmitting &&
-    !!values.name.trim() &&
-    (editingSync
-      ? isDirty
-      : values.importType === "file"
-        ? !!values.file
-        : !!values.url.trim());
+  const {
+    syncs,
+    syncErrors,
+    editingSync,
+    formOpen,
+    values,
+    setField,
+    isSubmitting,
+    isSyncing,
+    isDeleting,
+    busy,
+    canSubmit,
+    deleteTargetId,
+    setDeleteTargetId,
+    showList,
+    startAdd,
+    startEdit,
+    guardUnsaved,
+    confirmProps,
+    handleSync,
+    handleAdd,
+    handleSave,
+    confirmDelete,
+  } = useExternalSyncPanel({ calendarId, onSyncComplete, onDirtyChange });
 
   return (
     <>
       <PanelBody>
         <div className="flex flex-col gap-3.5">
-          {syncs.length === 0 && mode.kind !== "add" && (
+          {syncs.length === 0 && !formOpen && (
             <p className="rounded-[11px] border border-dashed border-control px-4 py-8 text-center text-[13px] text-fg-tertiary">
               {t("externalSync.noSyncs")}
             </p>

--- a/components/form-kit.tsx
+++ b/components/form-kit.tsx
@@ -51,7 +51,8 @@ export function SectionLabel({ children, className }: { children: ReactNode; cla
   return <div className={cn("eyebrow mb-2", className)}>{children}</div>;
 }
 
-export const inputClass = "h-10 rounded-[9px] px-3 text-[14px]";
+// text-base (16px) below md prevents iOS Safari's auto-zoom on focus
+export const inputClass = "h-10 rounded-[9px] px-3 text-base md:text-[14px]";
 
 export function ColorSwatches({
   value,

--- a/components/month-grid.tsx
+++ b/components/month-grid.tsx
@@ -649,7 +649,7 @@ export function MonthGrid({
                   : cn(
                       weekend ? "bg-surface-weekend" : "bg-surface-cell",
                       "hover:bg-surface-panel",
-                      (selected || today) && "shadow-[inset_0_0_0_1.5px_var(--brand-dot)]"
+                      selected && "shadow-[inset_0_0_0_1.5px_var(--brand-dot)]"
                     ),
                 desktop && "gap-[3px] px-2 py-[7px]",
                 variant === "compare" && "px-[9px] py-2",

--- a/components/month-grid.tsx
+++ b/components/month-grid.tsx
@@ -605,7 +605,7 @@ export function MonthGrid({
           const selected = isSameDay(day, selectedDay);
           const weekend = day.getDay() === 0 || day.getDay() === 6;
           const highlighted =
-            !phone && !!highlightColor && !today && highlightedWeekdays.includes(day.getDay());
+            !phone && !!highlightColor && highlightedWeekdays.includes(day.getDay());
           const toggling = togglingDates.has(key);
 
           const content = dayContents.get(key)!;
@@ -647,13 +647,9 @@ export function MonthGrid({
                 phone
                   ? "gap-[3px] rounded-[6px] px-[2px] pt-[5px] [contain:size]"
                   : cn(
-                      today
-                        ? "bg-surface-today"
-                        : weekend
-                          ? "bg-surface-weekend"
-                          : "bg-surface-cell",
-                      !today && "hover:bg-surface-panel",
-                      selected && "shadow-[inset_0_0_0_1.5px_var(--brand-dot)]"
+                      weekend ? "bg-surface-weekend" : "bg-surface-cell",
+                      "hover:bg-surface-panel",
+                      (selected || today) && "shadow-[inset_0_0_0_1.5px_var(--brand-dot)]"
                     ),
                 desktop && "gap-[3px] px-2 py-[7px]",
                 variant === "compare" && "px-[9px] py-2",

--- a/components/note-sheet.tsx
+++ b/components/note-sheet.tsx
@@ -288,7 +288,7 @@ export function NoteSheet({
                   value={form.interval}
                   onChange={(e) => update({ interval: Math.max(1, parseInt(e.target.value) || 1) })}
                   disabled={isReadOnly || form.repeat === "none"}
-                  className="h-[34px] w-[58px] rounded-lg px-2 text-center font-mono text-[14px] md:text-[14px]"
+                  className="h-[34px] w-[58px] rounded-lg px-2 text-center font-mono text-base md:text-[14px]"
                 />
                 <span>{unitLabel}</span>
               </div>

--- a/components/shift-form-fields.tsx
+++ b/components/shift-form-fields.tsx
@@ -129,7 +129,7 @@ export function ShiftFormFields({
           onChange={(e) => onFormDataChange({ ...formData, notes: e.target.value })}
           disabled={readOnly}
           rows={3}
-          className="min-h-16 resize-none rounded-[9px] px-3 py-2.5 text-[14px] md:text-[14px]"
+          className="min-h-16 resize-none rounded-[9px] px-3 py-2.5 text-base md:text-[14px]"
         />
       </Field>
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,5 +11,6 @@ services:
       - "3000:3000"
     volumes:
       - ./data:/app/data
+      - ./uploads:/app/public/uploads
     env_file:
       - .env

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,14 +5,22 @@
 
 set -e
 
+# Mirrors lib/db/db-path.mjs's resolveDatabasePath(): DATABASE_URL wins, else
+# the default under /app/data. A custom DATABASE_URL needs its own directory
+# chowned, not the hardcoded default -- otherwise db:migrate still fails as
+# "node" even though this script ran.
+db_path="${DATABASE_URL#file:}"
+db_path="${db_path:-/app/data/sqlite.db}"
+db_dir="$(dirname "$db_path")"
+
 # Already non-root: nothing to drop to, and no privilege to chown with. Both
 # paths ship owned by "node"; any other uid needs the host side sorted out.
 if [ "$(id -u)" != "0" ]; then
-    mkdir -p /app/data /app/public/uploads 2>/dev/null || true
+    mkdir -p "$db_dir" /app/public/uploads 2>/dev/null || true
     exec "$@"
 fi
 
-for dir in /app/data /app/public/uploads; do
+for dir in "$db_dir" /app/public/uploads; do
     mkdir -p "$dir"
     owner="$(stat -c '%u:%g' "$dir")"
     if [ "$owner" != "$(id -u node):$(id -g node)" ]; then

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,11 +1,12 @@
 import "dotenv/config";
 import { defineConfig } from "drizzle-kit";
+import { resolveDatabasePath } from "./lib/db/db-path.mjs";
 
 export default defineConfig({
   out: "./drizzle",
   schema: "./lib/db/schema.ts",
   dialect: "sqlite",
   dbCredentials: {
-    url: process.env.DATABASE_URL || "./data/sqlite.db",
+    url: resolveDatabasePath(),
   },
 });

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -18,36 +18,6 @@ const eslintConfig = defineConfig([
     // it, so linting it only ever breaks `npm test` on a working copy.
     ".LOCAL/**",
   ]),
-  {
-    // eslint-plugin-react-hooks v7 added three compiler-based rules that flag
-    // pre-existing patterns across the dialog/sheet components and the page
-    // routes. They are real findings, but fixing them touches component logic
-    // that is out of scope for this maintenance sweep, so they are demoted to
-    // warnings to keep CI actionable. The list is deliberately explicit rather
-    // than repo-wide: a new violation in any other file still fails the build,
-    // and the list shrinks as these files are reworked — tracked as follow-up
-    // work. Note that the rule engine stops after the first diagnosis per
-    // function, so fixing one finding can uncover others in the same file.
-    files: [
-      "app/admin/page.tsx",
-      "app/login/page.tsx",
-      "app/page.tsx",
-      "app/profile/page.tsx",
-      "app/register/page.tsx",
-      "components/admin/calendar-edit-sheet.tsx",
-      "components/changelog-dialog.tsx",
-      "components/export-dialog.tsx",
-      "components/external-sync-manage-sheet.tsx",
-      "components/note-sheet.tsx",
-      "components/preset-manage-sheet.tsx",
-      "components/shift-sheet.tsx",
-    ],
-    rules: {
-      "react-hooks/set-state-in-effect": "warn",
-      "react-hooks/refs": "warn",
-      "react-hooks/immutability": "warn",
-    },
-  },
 ]);
 
 export default eslintConfig;

--- a/hooks/useCompareMode.ts
+++ b/hooks/useCompareMode.ts
@@ -1,0 +1,216 @@
+"use client";
+
+import { useState, useEffect, useCallback } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+import { isSameDay, isSameMonth } from "date-fns";
+import { toast } from "sonner";
+import { useTranslations } from "next-intl";
+import { CalendarWithCount } from "@/lib/types";
+import { useCompareData } from "@/hooks/useCompareData";
+import { formatDateToLocal, parseLocalDate } from "@/lib/date-utils";
+
+function toDate(date: Date | string): Date {
+  return typeof date === "string" && /^\d{4}-\d{2}-\d{2}$/.test(date)
+    ? parseLocalDate(date)
+    : new Date(date);
+}
+
+interface UseCompareModeProps {
+  calendars: CalendarWithCount[];
+  hasLoadedOnce: boolean;
+  selectedCalendar: string | undefined;
+  currentDate: Date;
+  setCurrentDate: (date: Date) => void;
+  selectDay: (day: Date) => void;
+  selectedPresetId: string | undefined;
+}
+
+export function useCompareMode({
+  calendars,
+  hasLoadedOnce,
+  selectedCalendar,
+  currentDate,
+  setCurrentDate,
+  selectDay,
+  selectedPresetId,
+}: UseCompareModeProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const t = useTranslations();
+
+  const [isCompareMode, setIsCompareMode] = useState(false);
+  const [showCompareSelector, setShowCompareSelector] = useState(false);
+  const [selectedCompareIds, setSelectedCompareIds] = useState<string[]>([]);
+  // Selection before the picker opened, restored on cancel
+  const [compareSnapshot, setCompareSnapshot] = useState<string[]>([]);
+  const [compareTogglingDates, setCompareTogglingDates] = useState<
+    Map<string, Set<string>>
+  >(new Map());
+  const [compareNoteCalendarId, setCompareNoteCalendarId] = useState<
+    string | undefined
+  >();
+
+  const compareData = useCompareData({
+    calendarIds: selectedCompareIds,
+    enabled: isCompareMode,
+  });
+
+  // Load compare mode from URL on initial load
+  useEffect(() => {
+    const compareParam = searchParams.get("compare");
+    if (compareParam && !isCompareMode) {
+      const calendarIds = compareParam.split(",").filter((id) => id.trim());
+      if (calendarIds.length >= 2 && calendarIds.length <= 3) {
+        const validIds = calendarIds.filter((id) =>
+          calendars.some((cal) => cal.id === id)
+        );
+        if (validIds.length >= 2) {
+          // Syncing from the URL (an external source), not from render state.
+          // eslint-disable-next-line react-hooks/set-state-in-effect
+          setSelectedCompareIds(validIds);
+          setIsCompareMode(true);
+        }
+      }
+    } else if (!compareParam && isCompareMode) {
+      setIsCompareMode(false);
+      setSelectedCompareIds([]);
+      setCompareTogglingDates(new Map());
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [searchParams, calendars]);
+
+  // The effect above only filters while entering compare mode. Access to one of
+  // the columns can be lost afterwards, and compare needs at least two.
+  useEffect(() => {
+    if (!isCompareMode || !hasLoadedOnce) return;
+    const stillAccessible = selectedCompareIds.filter((id) =>
+      calendars.some((cal) => cal.id === id)
+    );
+    if (stillAccessible.length === selectedCompareIds.length) return;
+    queueMicrotask(() => {
+      if (stillAccessible.length >= 2) {
+        setSelectedCompareIds(stillAccessible);
+      } else {
+        setIsCompareMode(false);
+        setSelectedCompareIds([]);
+        setCompareTogglingDates(new Map());
+      }
+    });
+  }, [isCompareMode, hasLoadedOnce, calendars, selectedCompareIds]);
+
+  const handleToggleCompareCalendar = useCallback((calendarId: string) => {
+    setSelectedCompareIds((prev) =>
+      prev.includes(calendarId)
+        ? prev.filter((id) => id !== calendarId)
+        : [...prev, calendarId]
+    );
+  }, []);
+
+  const handleExitCompare = useCallback(() => {
+    setIsCompareMode(false);
+    setSelectedCompareIds([]);
+    setCompareTogglingDates(new Map());
+    router.replace(selectedCalendar ? `/?id=${selectedCalendar}` : `/`, {
+      scroll: false,
+    });
+  }, [router, selectedCalendar]);
+
+  const updateCompareToggling = useCallback(
+    (calendarId: string, dateKey: string, add: boolean) => {
+      setCompareTogglingDates((prev) => {
+        const updated = new Map(prev);
+        const next = new Set(updated.get(calendarId) || []);
+        if (add) next.add(dateKey);
+        else next.delete(dateKey);
+        updated.set(calendarId, next);
+        return updated;
+      });
+    },
+    []
+  );
+
+  const openComparePicker = useCallback(() => {
+    setCompareSnapshot(isCompareMode ? selectedCompareIds : []);
+    setShowCompareSelector(true);
+  }, [isCompareMode, selectedCompareIds]);
+
+  const handleCompareDayClick = useCallback(
+    async (calendarId: string, date: Date | string) => {
+      const targetDate = toDate(date);
+      selectDay(targetDate);
+      if (!isSameMonth(targetDate, currentDate)) setCurrentDate(targetDate);
+      if (!selectedPresetId) return;
+
+      const calendarPresets = compareData.presetsMap.get(calendarId) || [];
+      const calendarShifts = compareData.shiftsMap.get(calendarId) || [];
+      const preset = calendarPresets.find((p) => p.id === selectedPresetId);
+      if (!preset) return;
+
+      const dateKey = formatDateToLocal(targetDate);
+      if (compareTogglingDates.get(calendarId)?.has(dateKey)) return;
+      updateCompareToggling(calendarId, dateKey, true);
+
+      try {
+        const existingShift = calendarShifts.find(
+          (shift) =>
+            shift.date &&
+            isSameDay(shift.date as Date, targetDate) &&
+            shift.title === preset.title &&
+            shift.startTime === preset.startTime &&
+            shift.endTime === preset.endTime
+        );
+
+        if (existingShift) {
+          await compareData.deleteShift({ calendarId, shiftId: existingShift.id });
+        } else {
+          await compareData.createShift({
+            calendarId,
+            formData: {
+              date: dateKey,
+              startTime: preset.startTime,
+              endTime: preset.endTime,
+              title: preset.title,
+              color: preset.color,
+              notes: preset.notes || "",
+              presetId: preset.id,
+              isAllDay: preset.isAllDay || false,
+            },
+          });
+        }
+      } catch (error) {
+        console.error("Failed to toggle shift:", error);
+        toast.error(t("common.error"));
+      } finally {
+        updateCompareToggling(calendarId, dateKey, false);
+      }
+    },
+    [
+      selectDay,
+      currentDate,
+      setCurrentDate,
+      selectedPresetId,
+      compareData,
+      compareTogglingDates,
+      updateCompareToggling,
+      t,
+    ]
+  );
+
+  return {
+    isCompareMode,
+    setIsCompareMode,
+    showCompareSelector,
+    setShowCompareSelector,
+    selectedCompareIds,
+    setSelectedCompareIds,
+    compareSnapshot,
+    compareTogglingDates,
+    compareNoteCalendarId,
+    setCompareNoteCalendarId,
+    compareData,
+    handleToggleCompareCalendar,
+    handleExitCompare,
+    openComparePicker,
+    handleCompareDayClick,
+  };
+}

--- a/hooks/useExternalSyncPanel.ts
+++ b/hooks/useExternalSyncPanel.ts
@@ -1,0 +1,292 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { useTranslations } from "next-intl";
+import { toast } from "sonner";
+import { ExternalSync } from "@/lib/db/schema";
+import { syncToFormValues, useExternalSyncForm } from "@/hooks/useExternalSyncForm";
+import { useExternalSync } from "@/hooks/useExternalSync";
+import { isRateLimitError, handleRateLimitError } from "@/lib/rate-limit-client";
+import { isValidCalendarUrl, detectCalendarSyncType } from "@/lib/external-calendar-utils";
+import { useGuardedAction, useReportDirty } from "@/hooks/useDirtyState";
+
+const MAX_FILE_SIZE = 5 * 1024 * 1024;
+
+type PanelMode = { kind: "list" } | { kind: "add" } | { kind: "edit"; syncId: string };
+
+interface UseExternalSyncPanelProps {
+  calendarId: string;
+  onSyncComplete?: () => void;
+  /** Lets the surrounding frame guard its close button against unsaved changes */
+  onDirtyChange?: (dirty: boolean) => void;
+}
+
+export function useExternalSyncPanel({
+  calendarId,
+  onSyncComplete,
+  onDirtyChange,
+}: UseExternalSyncPanelProps) {
+  const t = useTranslations();
+  const [mode, setMode] = useState<PanelMode>({ kind: "list" });
+  const [isSyncing, setIsSyncing] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState<string | null>(null);
+  const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { values, setField, reset, isDirty } = useExternalSyncForm();
+  const itemLabel = t("externalSync.syncTypeCustom");
+
+  const { externalSyncs: syncs, syncLogs, refetch: invalidateSyncs } = useExternalSync(calendarId);
+
+  // Latest unread error per sync; marking logs as read clears it.
+  const syncErrors = useMemo(() => {
+    const errors: Record<string, string> = {};
+    for (const sync of syncs) {
+      const latestError = syncLogs.find(
+        (log) => log.externalSyncId === sync.id && log.status === "error" && !log.isRead
+      );
+      if (latestError) {
+        errors[sync.id] = latestError.errorMessage || t("syncNotifications.statusError");
+      }
+    }
+    return errors;
+  }, [syncs, syncLogs, t]);
+
+  const editingSync =
+    mode.kind === "edit" ? syncs.find((sync) => sync.id === mode.syncId) ?? null : null;
+  const formOpen = mode.kind === "add" || editingSync !== null;
+
+  const hasUnsavedChanges = formOpen && isDirty;
+
+  useReportDirty(hasUnsavedChanges, onDirtyChange);
+
+  const showList = () => {
+    setMode({ kind: "list" });
+    reset();
+  };
+
+  const startAdd = () => {
+    setMode({ kind: "add" });
+    reset();
+  };
+
+  const startEdit = (sync: ExternalSync) => {
+    setMode({ kind: "edit", syncId: sync.id });
+    reset(syncToFormValues(sync));
+  };
+
+  /** Runs `action` right away, or after confirming that unsaved input may be dropped. */
+  const { guarded: guardUnsaved, confirmProps } = useGuardedAction(hasUnsavedChanges);
+
+  const handleSync = async (syncId: string) => {
+    setIsSyncing(syncId);
+    try {
+      const response = await fetch(`/api/external-syncs/${syncId}/sync`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+
+      if (isRateLimitError(response)) {
+        await handleRateLimitError(response, t);
+        return;
+      }
+
+      const data = await response.json();
+      if (!response.ok) {
+        throw new Error(data.error || "Failed to sync calendar");
+      }
+
+      invalidateSyncs();
+      onSyncComplete?.();
+
+      const stats = data.stats || { created: 0, updated: 0, deleted: 0 };
+      toast.success(
+        `${t("common.success")}: ${t("common.createdCount", {
+          count: stats.created,
+        })}, ${t("common.updatedCount", {
+          count: stats.updated,
+        })}, ${t("common.deletedCount", { count: stats.deleted })}`
+      );
+    } catch (error) {
+      console.error("Sync error:", error);
+      toast.error(error instanceof Error ? error.message : t("common.error"));
+    } finally {
+      setIsSyncing(null);
+    }
+  };
+
+  const handleAdd = async () => {
+    const name = values.name.trim();
+    const url = values.url.trim();
+    if (!name) return;
+
+    if (values.importType === "file") {
+      if (!values.file) {
+        toast.error(t("validation.fileRequired"));
+        return;
+      }
+      if (values.file.size > MAX_FILE_SIZE) {
+        toast.error(t("validation.fileTooLarge", { maxSize: "5MB" }));
+        return;
+      }
+    } else {
+      if (!url) {
+        toast.error(t("validation.urlRequired"));
+        return;
+      }
+      if (!isValidCalendarUrl(url, detectCalendarSyncType(url))) {
+        toast.error(t("validation.urlInvalid"));
+        return;
+      }
+      // Uploaded files are stored as data URLs and never collide.
+      const exists = syncs.some(
+        (sync) => !sync.isOneTimeImport && sync.calendarUrl.toLowerCase() === url.toLowerCase()
+      );
+      if (exists) {
+        toast.error(t("validation.urlAlreadyExists"));
+        return;
+      }
+    }
+
+    setIsSubmitting(true);
+    try {
+      const icsContent =
+        values.importType === "file" && values.file ? await values.file.text() : undefined;
+
+      const response = await fetch("/api/external-syncs", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          calendarId,
+          name,
+          calendarUrl: url || undefined,
+          color: values.color,
+          displayMode: values.displayMode,
+          autoSyncInterval: values.autoSyncInterval,
+          icsContent,
+          isHidden: values.isHidden,
+          hideFromStats: values.hideFromStats,
+        }),
+      });
+
+      if (response.ok) {
+        const newSync = await response.json();
+        showList();
+        invalidateSyncs();
+        onSyncComplete?.();
+        toast.success(t("common.created", { item: itemLabel }));
+        await handleSync(newSync.id);
+      } else {
+        const data = await response.json();
+        toast.error(data.error || t("common.createError", { item: itemLabel }));
+      }
+    } catch (error) {
+      console.error("Failed to create sync:", error);
+      toast.error(t("common.createError", { item: itemLabel }));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleSave = async () => {
+    if (!editingSync) return;
+
+    setIsSubmitting(true);
+    try {
+      const response = await fetch(`/api/external-syncs/${editingSync.id}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: values.name.trim(),
+          calendarUrl: !editingSync.isOneTimeImport ? values.url.trim() : undefined,
+          color: values.color,
+          displayMode: values.displayMode,
+          autoSyncInterval: values.autoSyncInterval,
+          isHidden: values.isHidden,
+          hideFromStats: values.hideFromStats,
+        }),
+      });
+
+      if (response.ok) {
+        invalidateSyncs();
+        onSyncComplete?.();
+        showList();
+        toast.success(t("common.updated", { item: itemLabel }));
+      } else {
+        const data = await response.json();
+        toast.error(data.error || t("common.updateError", { item: itemLabel }));
+      }
+    } catch (error) {
+      console.error("Failed to save sync:", error);
+      toast.error(t("common.updateError", { item: itemLabel }));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const confirmDelete = async () => {
+    const syncId = deleteTargetId;
+    if (!syncId) return;
+
+    setIsDeleting(syncId);
+    try {
+      const response = await fetch(`/api/external-syncs/${syncId}`, {
+        method: "DELETE",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({}),
+      });
+
+      if (response.ok) {
+        if (mode.kind === "edit" && mode.syncId === syncId) showList();
+        invalidateSyncs();
+        onSyncComplete?.();
+        toast.success(t("common.deleted", { item: itemLabel }));
+      } else {
+        const data = await response.json();
+        toast.error(data.error || t("common.deleteError", { item: itemLabel }));
+      }
+    } catch (error) {
+      console.error("Error deleting sync:", error);
+      toast.error(t("common.deleteError", { item: itemLabel }));
+    } finally {
+      setIsDeleting(null);
+      setDeleteTargetId(null);
+    }
+  };
+
+  const busy = !!isSyncing || !!isDeleting;
+  const canSubmit =
+    !isSubmitting &&
+    !!values.name.trim() &&
+    (editingSync
+      ? isDirty
+      : values.importType === "file"
+        ? !!values.file
+        : !!values.url.trim());
+
+  return {
+    syncs,
+    syncErrors,
+    editingSync,
+    formOpen,
+    itemLabel,
+    values,
+    setField,
+    isSubmitting,
+    isSyncing,
+    isDeleting,
+    busy,
+    canSubmit,
+    deleteTargetId,
+    setDeleteTargetId,
+    showList,
+    startAdd,
+    startEdit,
+    guardUnsaved,
+    confirmProps,
+    handleSync,
+    handleAdd,
+    handleSave,
+    confirmDelete,
+  };
+}

--- a/lib/db/db-path.mjs
+++ b/lib/db/db-path.mjs
@@ -1,8 +1,8 @@
 import path from "node:path";
 
-// Shared by lib/db/index.ts and scripts/migrate.mjs. If these two ever resolve
-// differently, migrations run against one file and the server opens another,
-// silently and with no error.
+// Shared by lib/db/index.ts, scripts/migrate.mjs and drizzle.config.ts. If these
+// ever resolve differently, drizzle-kit, the migrator and the server end up
+// pointed at different files, silently and with no error.
 export function resolveDatabasePath() {
   return (
     process.env.DATABASE_URL?.replace("file:", "") ||

--- a/next.config.ts
+++ b/next.config.ts
@@ -22,29 +22,8 @@ const nextConfig: NextConfig = {
   },
 
   async headers() {
-    const isDev = process.env.NODE_ENV === "development";
-
-    // Content Security Policy. 'unsafe-inline' stays in script-src because the
-    // App Router streams its RSC payload through inline bootstrap scripts;
-    // removing it requires a per-request nonce, which in turn forces every
-    // page into dynamic rendering (see the Next.js "Content Security Policy"
-    // guide). 'unsafe-eval' is only needed by React's development build for
-    // readable server stack traces, so production does without it.
-    const csp = [
-      "default-src 'self'",
-      `script-src 'self' 'unsafe-inline'${isDev ? " 'unsafe-eval'" : ""}`,
-      "style-src 'self' 'unsafe-inline'", // Required for Tailwind
-      "img-src 'self' data: https:",
-      "font-src 'self' data:",
-      "connect-src 'self'",
-      "frame-ancestors 'none'",
-      // Cheap hardening that costs nothing here: no plugin content, no
-      // rewritten <base>, and forms may only post back to this origin.
-      "object-src 'none'",
-      "base-uri 'self'",
-      "form-action 'self'",
-    ].join("; ");
-
+    // Content-Security-Policy is set per-request in proxy.ts instead, since it
+    // carries a fresh nonce for every response.
     return [
       {
         source: "/(.*)",
@@ -64,10 +43,6 @@ const nextConfig: NextConfig = {
           {
             key: "X-XSS-Protection",
             value: "1; mode=block",
-          },
-          {
-            key: "Content-Security-Policy",
-            value: csp,
           },
         ],
       },

--- a/proxy.ts
+++ b/proxy.ts
@@ -87,6 +87,37 @@ function redirectToLogin(request: NextRequest) {
 }
 
 /**
+ * Every route is already dynamically rendered (next-intl's request config reads
+ * cookies()/headers()), so a fresh nonce per request costs nothing extra here.
+ * 'unsafe-inline' stays in style-src because Radix sets inline `style` attributes
+ * at runtime, which a nonce cannot cover.
+ */
+function buildCsp(nonce: string) {
+  const isDev = process.env.NODE_ENV === "development";
+  return [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'${isDev ? " 'unsafe-eval'" : ""}`,
+    "style-src 'self' 'unsafe-inline'",
+    "img-src 'self' data: https:",
+    "font-src 'self' data:",
+    "connect-src 'self'",
+    "frame-ancestors 'none'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+  ].join("; ");
+}
+
+/** NextResponse.next() carrying the request-side x-nonce header and the CSP response header. */
+function nextWithNonce(request: NextRequest, nonce: string, csp: string) {
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-nonce", nonce);
+  const response = NextResponse.next({ request: { headers: requestHeaders } });
+  response.headers.set("Content-Security-Policy", csp);
+  return response;
+}
+
+/**
  * Proxy for authentication and route protection (Next.js 16)
  *
  * Features:
@@ -100,6 +131,8 @@ function redirectToLogin(request: NextRequest) {
  */
 export async function proxy(request: NextRequest) {
   const { pathname } = request.nextUrl;
+  const nonce = Buffer.from(crypto.randomUUID()).toString("base64");
+  const csp = buildCsp(nonce);
 
   // =====================================================
   // Health Check - Block all routes if system unhealthy
@@ -127,7 +160,7 @@ export async function proxy(request: NextRequest) {
       }
 
       // System is unhealthy - allow access to error page
-      return NextResponse.next();
+      return nextWithNonce(request, nonce, csp);
     } catch (error) {
       // Log the error instead of silently swallowing it
       console.error(
@@ -135,7 +168,7 @@ export async function proxy(request: NextRequest) {
         error instanceof Error ? error.message : String(error)
       );
       // Always treat fetch failures/timeouts as "unhealthy" to allow access to error page
-      return NextResponse.next();
+      return nextWithNonce(request, nonce, csp);
     }
   }
 
@@ -233,7 +266,7 @@ export async function proxy(request: NextRequest) {
 
   // If auth is disabled, allow all routes
   if (!isAuthEnabled()) {
-    return NextResponse.next();
+    return nextWithNonce(request, nonce, csp);
   }
 
   // Public routes that don't require authentication
@@ -254,7 +287,7 @@ export async function proxy(request: NextRequest) {
 
   // Allow public routes
   if (isPublicRoute) {
-    return NextResponse.next();
+    return nextWithNonce(request, nonce, csp);
   }
 
   // =====================================================
@@ -321,7 +354,7 @@ export async function proxy(request: NextRequest) {
   if (!sessionToken) {
     // If guest access is enabled, allow viewing without login
     if (allowGuestAccess()) {
-      return NextResponse.next();
+      return nextWithNonce(request, nonce, csp);
     }
 
     // Otherwise, redirect to login with return URL
@@ -331,10 +364,10 @@ export async function proxy(request: NextRequest) {
   // Session token validation happens in API routes via getSessionUser()
   // Middleware only checks for cookie presence (fast routing decision)
 
-  // Security headers (X-Content-Type-Options, X-Frame-Options, Referrer-Policy,
-  // X-XSS-Protection, Content-Security-Policy) are set globally in next.config.ts
-  // so they apply to every response, not just this fall-through branch.
-  return NextResponse.next();
+  // The remaining security headers (X-Content-Type-Options, X-Frame-Options,
+  // Referrer-Policy, X-XSS-Protection) are set globally in next.config.ts;
+  // only the nonce-based Content-Security-Policy has to be per-request.
+  return nextWithNonce(request, nonce, csp);
 }
 
 // Configure which routes to run proxy on


### PR DESCRIPTION
## Summary
Closes the seven tech-debt items from `.LOCAL/OFFENE-PUNKTE.md` that were deliberately deferred out of the #148 maintenance sweep, all built on top of the redesign in #182:

- `fix(db)` / `fix(docker)`: drizzle-kit and the entrypoint's chown step now resolve `DATABASE_URL` through the shared `resolveDatabasePath()` helper instead of a hardcoded path; avatars persist across container restarts via a new `docker-compose.yml` volume.
- `fix(hooks)` / `refactor(page)`: cleared the last `react-hooks/set-state-in-effect` warning and removed the `eslint.config.mjs` override that had silenced the v7 hook-compiler rules for 12 legacy files; extracted compare mode out of `app/page.tsx` into `hooks/useCompareMode.ts` (622 → 500 lines).
- `refactor(sync)`: split `components/external-sync-manage-sheet.tsx` the same way, moving its fetch/mutation logic into `hooks/useExternalSyncPanel.ts`.
- `fix(forms)`: fixed iOS Safari auto-zoom on focus for number/time/note inputs (shared `inputClass` was pinning font-size to 14px below the 16px zoom threshold).
- `feat(security)`: moved CSP `script-src` from `'unsafe-inline'` to per-request nonces, generated in `proxy.ts` and threaded through `app/layout.tsx` and `next-themes`. Every route already renders dynamically (next-intl reads `cookies()`/`headers()`), so this adds no new rendering cost — verified with a production build.
- Two incidental UI bugs reported during this work: today's cell no longer gets a different highlight background than other highlighted days, and the day-cell border now only appears on the selected day instead of stacking on both today and the selection.
- `README.md`'s feature table was reviewed and is still accurate; its two screenshots are confirmed stale (pre-redesign UI) but couldn't be refreshed here — no GitHub-attachment upload capability, no admin credentials in this environment, and the local guest demo data isn't presentable. Flagged in `.LOCAL/OFFENE-PUNKTE.md` for manual follow-up.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npm run lint`
- [x] `npm run build` (all routes still render dynamically as before)
- [x] `npm run i18n`
- [x] Manual browser verification: drizzle migration against a custom `DATABASE_URL`, mobile-viewport input zoom fix, CSP headers + zero console violations in both dev and a production build, day-cell border/highlight fix

https://claude.ai/code/session_01NLKmoH2kgmjNaC4tTLC8Yu